### PR TITLE
Add unit testing dependency and starting unit test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@
 # IntelliJ IDEA
 /.idea/
 
+/.vscode/
+
 # Build artifacts
 /exporters/trace/build/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Gradle
 /.gradle/
 /out/
+.project
+.settings
+.classpath
 
 # IntelliJ IDEA
 /.idea/
@@ -9,4 +12,5 @@
 
 # Build artifacts
 /exporters/trace/build/
+/exporters/trace/bin/
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,13 @@ subprojects {
     ext {
         googleCloudVersion = '1.0.2'
         openTelemetryVersion = '0.3.0'
+        junitVersion = '4.13';
 
         libraries = [
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
                 opentelemetry_api:"io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
+                junit:"junit:junit:${junitVersion}"
         ]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ subprojects {
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
                 opentelemetry_api:"io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
+        ]
+        testLibraries = [
                 junit:"junit:junit:${junitVersion}"
         ]
     }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
-		testImplementation('junit:junit:4.13')
+    testImplementation('junit:junit:4.13')
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,7 +1,12 @@
+plugins {
+    id 'java'
+}
+
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
 dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
+		testImplementation('junit:junit:4.13')
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
-    testImplementation('junit:junit:4.13')
+    api(libraries.junit)
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
-    api(testLibraries.junit)
+    testImplementation(testLibraries.junit)
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
-    api(libraries.junit)
+    api(testLibraries.junit)
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java'
-}
-
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
 dependencies {

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -1,0 +1,23 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.devtools.cloudtrace.v2.AttributeValue;
+import static org.junit.Assert.assertNotNull;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.Map;
+import java.util.HashMap;
+import org.junit.Test;
+
+@RunWith(JUnit4.class)
+
+public class TraceExporterTest {
+
+  private final String PROJECT_ID = "project";
+  private final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>();
+
+  @Test
+  public void exporterConstructorTest() {
+    final TraceExporter exporter = new TraceExporter(PROJECT_ID, null, FIXED_ATTRIBUTES);
+    assertNotNull(exporter);
+  }
+}

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import org.junit.Test;
 
 @RunWith(JUnit4.class)
-
 public class TraceExporterTest {
 
   private final String PROJECT_ID = "project";


### PR DESCRIPTION
**Context**
One of the issues in the repo right now is to add unit testing.

**Solution**
I added Junit4 instead of Junit5 because Junit5 is not compatible with java 8, which is defined in https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/blob/master/build.gradle. If you feel that we should be supporting Java8, let's have a conversation.

The current test is a constructor test, which isn't all that useful in itself but it shows that the testing dependency works and allows anybody who wants to write a unit test in the future to have a reference to go off of.

In addition, I added some elements to the `.gitignore` of things that I thought were best not to commit


**Test plan**
```sh
$ cd exporters/trace && gradle test

BUILD SUCCESSFUL in 4s
3 actionable tasks: 3 up-to-date
```
