### PR TITLE
Create a TraceConfiguration file and unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,16 @@ subprojects {
     }
 
     ext {
+        autoValueVersion = '1.7.4'
+        googleAuthVersion = '0.20.0';
         googleCloudVersion = '1.0.2'
         openTelemetryVersion = '0.3.0'
         junitVersion = '4.13';
 
         libraries = [
+                auto_value_annotations: "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
+                auto_value: "com.google.auto.value:auto-value:${autoValueVersion}",
+                google_cloud_core: "com.google.cloud:google-cloud-core:${googleCloudVersion}",
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
                 opentelemetry_api:"io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ subprojects {
 
     ext {
         autoValueVersion = '1.7.4'
-        googleAuthVersion = '0.20.0';
         googleCloudVersion = '1.0.2'
         openTelemetryVersion = '0.3.0'
         junitVersion = '4.13';

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
         ]
         testLibraries = [
-                junit:"junit:junit:${junitVersion}"
+                junit:"junit:junit:${junitVersion}",
         ]
     }
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,8 +1,11 @@
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
 dependencies {
+    api(libraries.auto_value_annotations)
+    annotationProcessor(libraries.auto_value)
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
+    api(libraries.google_cloud_core)
     api(libraries.google_cloud_trace)
     testImplementation(testLibraries.junit)
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -29,8 +29,7 @@ public abstract class TraceConfiguration {
     @VisibleForTesting
     static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
 
-    TraceConfiguration() {
-    }
+    TraceConfiguration() {}
 
     /**
      * Returns the {@link Credentials}.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
+
 import java.util.Collections;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -17,7 +18,6 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * Configurations for {@link TraceConfiguration}.
- *
  */
 @AutoValue
 @Immutable
@@ -28,7 +28,8 @@ public abstract class TraceConfiguration {
     @VisibleForTesting
     static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
 
-    TraceConfiguration() {}
+    TraceConfiguration() {
+    }
 
     /**
      * Returns the {@link Credentials}.
@@ -82,7 +83,6 @@ public abstract class TraceConfiguration {
 
     /**
      * Builder for {@link TraceConfiguration}.
-     *
      */
     @AutoValue.Builder
     public abstract static class Builder {

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -9,12 +9,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 
-import java.util.Collections;
-import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Configurations for {@link TraceConfiguration}.
@@ -23,147 +23,147 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class TraceConfiguration {
 
-    private static final String DEFAULT_PROJECT_ID = Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
+  private static final String DEFAULT_PROJECT_ID = Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
+
+  @VisibleForTesting
+  static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
+
+  TraceConfiguration() {
+  }
+
+  /**
+   * Returns the {@link Credentials}.
+   *
+   * @return the {@code Credentials}.
+   */
+  @Nullable
+  public abstract Credentials getCredentials();
+
+  /**
+   * Returns the cloud project id.
+   *
+   * @return the cloud project id.
+   */
+  public abstract String getProjectId();
+
+  /**
+   * Returns a TraceServiceStub instance used to make RPC calls.
+   *
+   * @return the trace service stub.
+   */
+  @Nullable
+  public abstract TraceServiceStub getTraceServiceStub();
+
+  /**
+   * Returns a map of attributes that is added to all the exported spans.
+   *
+   * @return the map of attributes that is added to all the exported spans.
+   */
+  public abstract Map<String, AttributeValue> getFixedAttributes();
+
+  /**
+   * Returns the deadline for exporting to Trace backend.
+   *
+   * <p>
+   * Default value is 10 seconds.
+   *
+   * @return the export deadline.
+   */
+  public abstract Duration getDeadline();
+
+  /**
+   * Returns a new {@link Builder}.
+   *
+   * @return a {@code Builder}.
+   */
+  public static Builder builder() {
+    return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
+            .setFixedAttributes(Collections.<String, AttributeValue>emptyMap()).setDeadline(DEFAULT_DEADLINE);
+  }
+
+  /**
+   * Builder for {@link TraceConfiguration}.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
 
     @VisibleForTesting
-    static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
+    static final Duration ZERO = Duration.ZERO;
 
-    TraceConfiguration() {
+    Builder() {
     }
 
     /**
-     * Returns the {@link Credentials}.
+     * Sets the {@link Credentials} used to authenticate API calls.
      *
-     * @return the {@code Credentials}.
+     * @param credentials the {@code Credentials}.
+     * @return this.
      */
-    @Nullable
-    public abstract Credentials getCredentials();
+    public abstract Builder setCredentials(Credentials credentials);
 
     /**
-     * Returns the cloud project id.
+     * Sets the cloud project id.
      *
-     * @return the cloud project id.
+     * @param projectId the cloud project id.
+     * @return this.
      */
-    public abstract String getProjectId();
+    public abstract Builder setProjectId(String projectId);
 
     /**
-     * Returns a TraceServiceStub instance used to make RPC calls.
+     * Sets the trace service stub used to send gRPC calls.
      *
-     * @return the trace service stub.
+     * @param traceServiceStub the {@code TraceServiceStub}.
+     * @return this.
      */
-    @Nullable
-    public abstract TraceServiceStub getTraceServiceStub();
+    public abstract Builder setTraceServiceStub(TraceServiceStub traceServiceStub);
 
     /**
-     * Returns a map of attributes that is added to all the exported spans.
+     * Sets the map of attributes that is added to all the exported spans.
      *
-     * @return the map of attributes that is added to all the exported spans.
+     * @param fixedAttributes the map of attributes that is added to all the
+     *                        exported spans.
+     * @return this.
      */
-    public abstract Map<String, AttributeValue> getFixedAttributes();
+    public abstract Builder setFixedAttributes(Map<String, AttributeValue> fixedAttributes);
 
     /**
-     * Returns the deadline for exporting to Trace backend.
+     * Sets the deadline for exporting to Trace backend.
      *
      * <p>
-     * Default value is 10 seconds.
+     * If both {@code TraceServiceStub} and {@code Deadline} are set,
+     * {@code TraceServiceStub} takes precedence and {@code Deadline} will not be
+     * respected.
      *
-     * @return the export deadline.
+     * @param deadline the export deadline.
+     * @return this
      */
-    public abstract Duration getDeadline();
+    public abstract Builder setDeadline(Duration deadline);
+
+    abstract String getProjectId();
+
+    abstract Map<String, AttributeValue> getFixedAttributes();
+
+    abstract Duration getDeadline();
+
+    abstract TraceConfiguration autoBuild();
 
     /**
-     * Returns a new {@link Builder}.
+     * Builds a {@link TraceConfiguration}.
      *
-     * @return a {@code Builder}.
+     * @return a {@code TraceConfiguration}.
      */
-    public static Builder builder() {
-        return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
-                .setFixedAttributes(Collections.<String, AttributeValue>emptyMap()).setDeadline(DEFAULT_DEADLINE);
+    public TraceConfiguration build() {
+      // Make a defensive copy of fixed attributes.
+      setFixedAttributes(
+              Collections.unmodifiableMap(new LinkedHashMap<String, AttributeValue>(getFixedAttributes())));
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(getProjectId()),
+              "Cannot find a project ID from either configurations or application default.");
+      for (Map.Entry<String, AttributeValue> fixedAttribute : getFixedAttributes().entrySet()) {
+        Preconditions.checkNotNull(fixedAttribute.getKey(), "attribute key");
+        Preconditions.checkNotNull(fixedAttribute.getValue(), "attribute value");
+      }
+      Preconditions.checkArgument(getDeadline().compareTo(ZERO) > 0, "Deadline must be positive.");
+      return autoBuild();
     }
-
-    /**
-     * Builder for {@link TraceConfiguration}.
-     */
-    @AutoValue.Builder
-    public abstract static class Builder {
-
-        @VisibleForTesting
-        static final Duration ZERO = Duration.ZERO;
-
-        Builder() {
-        }
-
-        /**
-         * Sets the {@link Credentials} used to authenticate API calls.
-         *
-         * @param credentials the {@code Credentials}.
-         * @return this.
-         */
-        public abstract Builder setCredentials(Credentials credentials);
-
-        /**
-         * Sets the cloud project id.
-         *
-         * @param projectId the cloud project id.
-         * @return this.
-         */
-        public abstract Builder setProjectId(String projectId);
-
-        /**
-         * Sets the trace service stub used to send gRPC calls.
-         *
-         * @param traceServiceStub the {@code TraceServiceStub}.
-         * @return this.
-         */
-        public abstract Builder setTraceServiceStub(TraceServiceStub traceServiceStub);
-
-        /**
-         * Sets the map of attributes that is added to all the exported spans.
-         *
-         * @param fixedAttributes the map of attributes that is added to all the
-         *                        exported spans.
-         * @return this.
-         */
-        public abstract Builder setFixedAttributes(Map<String, AttributeValue> fixedAttributes);
-
-        /**
-         * Sets the deadline for exporting to Trace backend.
-         *
-         * <p>
-         * If both {@code TraceServiceStub} and {@code Deadline} are set,
-         * {@code TraceServiceStub} takes precedence and {@code Deadline} will not be
-         * respected.
-         *
-         * @param deadline the export deadline.
-         * @return this
-         */
-        public abstract Builder setDeadline(Duration deadline);
-
-        abstract String getProjectId();
-
-        abstract Map<String, AttributeValue> getFixedAttributes();
-
-        abstract Duration getDeadline();
-
-        abstract TraceConfiguration autoBuild();
-
-        /**
-         * Builds a {@link TraceConfiguration}.
-         *
-         * @return a {@code TraceConfiguration}.
-         */
-        public TraceConfiguration build() {
-            // Make a defensive copy of fixed attributes.
-            setFixedAttributes(
-                    Collections.unmodifiableMap(new LinkedHashMap<String, AttributeValue>(getFixedAttributes())));
-            Preconditions.checkArgument(!Strings.isNullOrEmpty(getProjectId()),
-                    "Cannot find a project ID from either configurations or application default.");
-            for (Map.Entry<String, AttributeValue> fixedAttribute : getFixedAttributes().entrySet()) {
-                Preconditions.checkNotNull(fixedAttribute.getKey(), "attribute key");
-                Preconditions.checkNotNull(fixedAttribute.getValue(), "attribute value");
-            }
-            Preconditions.checkArgument(getDeadline().compareTo(ZERO) > 0, "Deadline must be positive.");
-            return autoBuild();
-        }
-    }
+  }
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -16,20 +16,17 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/**
- * Configurations for {@link TraceConfiguration}.
- */
+/** Configurations for {@link TraceConfiguration}. */
 @AutoValue
 @Immutable
 public abstract class TraceConfiguration {
 
-  private static final String DEFAULT_PROJECT_ID = Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
+  private static final String DEFAULT_PROJECT_ID =
+      Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
 
-  @VisibleForTesting
-  static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
+  @VisibleForTesting static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
 
-  TraceConfiguration() {
-  }
+  TraceConfiguration() {}
 
   /**
    * Returns the {@link Credentials}.
@@ -64,8 +61,7 @@ public abstract class TraceConfiguration {
   /**
    * Returns the deadline for exporting to Trace backend.
    *
-   * <p>
-   * Default value is 10 seconds.
+   * <p>Default value is 10 seconds.
    *
    * @return the export deadline.
    */
@@ -77,21 +73,19 @@ public abstract class TraceConfiguration {
    * @return a {@code Builder}.
    */
   public static Builder builder() {
-    return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
-            .setFixedAttributes(Collections.emptyMap()).setDeadline(DEFAULT_DEADLINE);
+    return new AutoValue_TraceConfiguration.Builder()
+        .setProjectId(DEFAULT_PROJECT_ID)
+        .setFixedAttributes(Collections.emptyMap())
+        .setDeadline(DEFAULT_DEADLINE);
   }
 
-  /**
-   * Builder for {@link TraceConfiguration}.
-   */
+  /** Builder for {@link TraceConfiguration}. */
   @AutoValue.Builder
   public abstract static class Builder {
 
-    @VisibleForTesting
-    static final Duration ZERO = Duration.ZERO;
+    @VisibleForTesting static final Duration ZERO = Duration.ZERO;
 
-    Builder() {
-    }
+    Builder() {}
 
     /**
      * Sets the {@link Credentials} used to authenticate API calls.
@@ -120,8 +114,7 @@ public abstract class TraceConfiguration {
     /**
      * Sets the map of attributes that is added to all the exported spans.
      *
-     * @param fixedAttributes the map of attributes that is added to all the
-     *                        exported spans.
+     * @param fixedAttributes the map of attributes that is added to all the exported spans.
      * @return this.
      */
     public abstract Builder setFixedAttributes(Map<String, AttributeValue> fixedAttributes);
@@ -129,10 +122,8 @@ public abstract class TraceConfiguration {
     /**
      * Sets the deadline for exporting to Trace backend.
      *
-     * <p>
-     * If both {@code TraceServiceStub} and {@code Deadline} are set,
-     * {@code TraceServiceStub} takes precedence and {@code Deadline} will not be
-     * respected.
+     * <p>If both {@code TraceServiceStub} and {@code Deadline} are set, {@code TraceServiceStub}
+     * takes precedence and {@code Deadline} will not be respected.
      *
      * @param deadline the export deadline.
      * @return this
@@ -155,9 +146,11 @@ public abstract class TraceConfiguration {
     public TraceConfiguration build() {
       // Make a defensive copy of fixed attributes.
       setFixedAttributes(
-              Collections.unmodifiableMap(new LinkedHashMap<String, AttributeValue>(getFixedAttributes())));
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(getProjectId()),
-              "Cannot find a project ID from either configurations or application default.");
+          Collections.unmodifiableMap(
+              new LinkedHashMap<String, AttributeValue>(getFixedAttributes())));
+      Preconditions.checkArgument(
+          !Strings.isNullOrEmpty(getProjectId()),
+          "Cannot find a project ID from either configurations or application default.");
       for (Map.Entry<String, AttributeValue> fixedAttribute : getFixedAttributes().entrySet()) {
         Preconditions.checkNotNull(fixedAttribute.getKey(), "attribute key");
         Preconditions.checkNotNull(fixedAttribute.getValue(), "attribute value");

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -7,7 +7,7 @@ import com.google.cloud.trace.v2.stub.TraceServiceStub;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import io.opentelemetry.common.AttributeValue;
+import com.google.devtools.cloudtrace.v2.AttributeValue;
 import java.util.Collections;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -18,7 +18,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Configurations for {@link TraceConfiguration}.
  *
- * @since 0.12
  */
 @AutoValue
 @Immutable
@@ -35,7 +34,6 @@ public abstract class TraceConfiguration {
      * Returns the {@link Credentials}.
      *
      * @return the {@code Credentials}.
-     * @since 0.12
      */
     @Nullable
     public abstract Credentials getCredentials();
@@ -44,7 +42,6 @@ public abstract class TraceConfiguration {
      * Returns the cloud project id.
      *
      * @return the cloud project id.
-     * @since 0.12
      */
     public abstract String getProjectId();
 
@@ -52,7 +49,6 @@ public abstract class TraceConfiguration {
      * Returns a TraceServiceStub instance used to make RPC calls.
      *
      * @return the trace service stub.
-     * @since 0.16
      */
     @Nullable
     public abstract TraceServiceStub getTraceServiceStub();
@@ -61,7 +57,6 @@ public abstract class TraceConfiguration {
      * Returns a map of attributes that is added to all the exported spans.
      *
      * @return the map of attributes that is added to all the exported spans.
-     * @since 0.19
      */
     public abstract Map<String, AttributeValue> getFixedAttributes();
 
@@ -72,7 +67,6 @@ public abstract class TraceConfiguration {
      * Default value is 10 seconds.
      *
      * @return the export deadline.
-     * @since 0.22
      */
     public abstract Duration getDeadline();
 
@@ -80,7 +74,6 @@ public abstract class TraceConfiguration {
      * Returns a new {@link Builder}.
      *
      * @return a {@code Builder}.
-     * @since 0.12
      */
     public static Builder builder() {
         return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
@@ -90,7 +83,6 @@ public abstract class TraceConfiguration {
     /**
      * Builder for {@link TraceConfiguration}.
      *
-     * @since 0.12
      */
     @AutoValue.Builder
     public abstract static class Builder {
@@ -106,7 +98,6 @@ public abstract class TraceConfiguration {
          *
          * @param credentials the {@code Credentials}.
          * @return this.
-         * @since 0.12
          */
         public abstract Builder setCredentials(Credentials credentials);
 
@@ -115,7 +106,6 @@ public abstract class TraceConfiguration {
          *
          * @param projectId the cloud project id.
          * @return this.
-         * @since 0.12
          */
         public abstract Builder setProjectId(String projectId);
 
@@ -124,7 +114,6 @@ public abstract class TraceConfiguration {
          *
          * @param traceServiceStub the {@code TraceServiceStub}.
          * @return this.
-         * @since 0.16
          */
         public abstract Builder setTraceServiceStub(TraceServiceStub traceServiceStub);
 
@@ -134,7 +123,6 @@ public abstract class TraceConfiguration {
          * @param fixedAttributes the map of attributes that is added to all the
          *                        exported spans.
          * @return this.
-         * @since 0.16
          */
         public abstract Builder setFixedAttributes(Map<String, AttributeValue> fixedAttributes);
 
@@ -148,7 +136,6 @@ public abstract class TraceConfiguration {
          *
          * @param deadline the export deadline.
          * @return this
-         * @since 0.22
          */
         public abstract Builder setDeadline(Duration deadline);
 
@@ -164,7 +151,6 @@ public abstract class TraceConfiguration {
          * Builds a {@link TraceConfiguration}.
          *
          * @return a {@code TraceConfiguration}.
-         * @since 0.12
          */
         public TraceConfiguration build() {
             // Make a defensive copy of fixed attributes.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Configurations for {@link TraceConfiguration}. */
+/** Configurations for {@link TraceExporter}. */
 @AutoValue
 @Immutable
 public abstract class TraceConfiguration {

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -8,10 +8,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.opentelemetry.common.AttributeValue;
-
-import java.time.Duration;
-// import io.opentelemetry.trace.AttributeValue;
 import java.util.Collections;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -31,7 +29,8 @@ public abstract class TraceConfiguration {
     @VisibleForTesting
     static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
 
-    TraceConfiguration() {}
+    TraceConfiguration() {
+    }
 
     /**
      * Returns the {@link Credentials}.
@@ -86,8 +85,7 @@ public abstract class TraceConfiguration {
      */
     public static Builder builder() {
         return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
-                .setFixedAttributes(Collections.<String, AttributeValue>emptyMap())
-                .setDeadline(DEFAULT_DEADLINE);
+                .setFixedAttributes(Collections.<String, AttributeValue>emptyMap()).setDeadline(DEFAULT_DEADLINE);
     }
 
     /**

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -78,7 +78,7 @@ public abstract class TraceConfiguration {
    */
   public static Builder builder() {
     return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
-            .setFixedAttributes(Collections.<String, AttributeValue>emptyMap()).setDeadline(DEFAULT_DEADLINE);
+            .setFixedAttributes(Collections.emptyMap()).setDeadline(DEFAULT_DEADLINE);
   }
 
   /**

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -1,0 +1,186 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.auth.Credentials;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.trace.v2.stub.TraceServiceStub;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.opentelemetry.common.AttributeValue;
+
+import java.time.Duration;
+// import io.opentelemetry.trace.AttributeValue;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Configurations for {@link TraceConfiguration}.
+ *
+ * @since 0.12
+ */
+@AutoValue
+@Immutable
+public abstract class TraceConfiguration {
+
+    private static final String DEFAULT_PROJECT_ID = Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
+
+    @VisibleForTesting
+    static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
+
+    TraceConfiguration() {}
+
+    /**
+     * Returns the {@link Credentials}.
+     *
+     * @return the {@code Credentials}.
+     * @since 0.12
+     */
+    @Nullable
+    public abstract Credentials getCredentials();
+
+    /**
+     * Returns the cloud project id.
+     *
+     * @return the cloud project id.
+     * @since 0.12
+     */
+    public abstract String getProjectId();
+
+    /**
+     * Returns a TraceServiceStub instance used to make RPC calls.
+     *
+     * @return the trace service stub.
+     * @since 0.16
+     */
+    @Nullable
+    public abstract TraceServiceStub getTraceServiceStub();
+
+    /**
+     * Returns a map of attributes that is added to all the exported spans.
+     *
+     * @return the map of attributes that is added to all the exported spans.
+     * @since 0.19
+     */
+    public abstract Map<String, AttributeValue> getFixedAttributes();
+
+    /**
+     * Returns the deadline for exporting to Trace backend.
+     *
+     * <p>
+     * Default value is 10 seconds.
+     *
+     * @return the export deadline.
+     * @since 0.22
+     */
+    public abstract Duration getDeadline();
+
+    /**
+     * Returns a new {@link Builder}.
+     *
+     * @return a {@code Builder}.
+     * @since 0.12
+     */
+    public static Builder builder() {
+        return new AutoValue_TraceConfiguration.Builder().setProjectId(DEFAULT_PROJECT_ID)
+                .setFixedAttributes(Collections.<String, AttributeValue>emptyMap())
+                .setDeadline(DEFAULT_DEADLINE);
+    }
+
+    /**
+     * Builder for {@link TraceConfiguration}.
+     *
+     * @since 0.12
+     */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @VisibleForTesting
+        static final Duration ZERO = Duration.ZERO;
+
+        Builder() {
+        }
+
+        /**
+         * Sets the {@link Credentials} used to authenticate API calls.
+         *
+         * @param credentials the {@code Credentials}.
+         * @return this.
+         * @since 0.12
+         */
+        public abstract Builder setCredentials(Credentials credentials);
+
+        /**
+         * Sets the cloud project id.
+         *
+         * @param projectId the cloud project id.
+         * @return this.
+         * @since 0.12
+         */
+        public abstract Builder setProjectId(String projectId);
+
+        /**
+         * Sets the trace service stub used to send gRPC calls.
+         *
+         * @param traceServiceStub the {@code TraceServiceStub}.
+         * @return this.
+         * @since 0.16
+         */
+        public abstract Builder setTraceServiceStub(TraceServiceStub traceServiceStub);
+
+        /**
+         * Sets the map of attributes that is added to all the exported spans.
+         *
+         * @param fixedAttributes the map of attributes that is added to all the
+         *                        exported spans.
+         * @return this.
+         * @since 0.16
+         */
+        public abstract Builder setFixedAttributes(Map<String, AttributeValue> fixedAttributes);
+
+        /**
+         * Sets the deadline for exporting to Trace backend.
+         *
+         * <p>
+         * If both {@code TraceServiceStub} and {@code Deadline} are set,
+         * {@code TraceServiceStub} takes precedence and {@code Deadline} will not be
+         * respected.
+         *
+         * @param deadline the export deadline.
+         * @return this
+         * @since 0.22
+         */
+        public abstract Builder setDeadline(Duration deadline);
+
+        abstract String getProjectId();
+
+        abstract Map<String, AttributeValue> getFixedAttributes();
+
+        abstract Duration getDeadline();
+
+        abstract TraceConfiguration autoBuild();
+
+        /**
+         * Builds a {@link TraceConfiguration}.
+         *
+         * @return a {@code TraceConfiguration}.
+         * @since 0.12
+         */
+        public TraceConfiguration build() {
+            // Make a defensive copy of fixed attributes.
+            setFixedAttributes(
+                    Collections.unmodifiableMap(new LinkedHashMap<String, AttributeValue>(getFixedAttributes())));
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(getProjectId()),
+                    "Cannot find a project ID from either configurations or application default.");
+            for (Map.Entry<String, AttributeValue> fixedAttribute : getFixedAttributes().entrySet()) {
+                Preconditions.checkNotNull(fixedAttribute.getKey(), "attribute key");
+                Preconditions.checkNotNull(fixedAttribute.getValue(), "attribute value");
+            }
+            Preconditions.checkArgument(getDeadline().compareTo(ZERO) > 0, "Deadline must be positive.");
+            return autoBuild();
+        }
+    }
+}

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -28,52 +28,53 @@ public class TraceExporter implements SpanExporter {
   private final String projectId;
   private final Map<String, AttributeValue> fixedAttributes;
 
-  static TraceExporter createWithConfiguration(TraceConfiguration configuration)
-          throws IOException {
+  public static TraceExporter createWithConfiguration(TraceConfiguration configuration)
+      throws IOException {
     String projectId = configuration.getProjectId();
     TraceServiceStub stub = configuration.getTraceServiceStub();
-    Credentials credentials = configuration.getCredentials();
 
     if (stub == null) {
+      Credentials credentials =
+          configuration.getCredentials() == null
+              ? GoogleCredentials.getApplicationDefault()
+              : configuration.getCredentials();
+
       return TraceExporter.createWithCredentials(
-              projectId,
-              credentials != null ? credentials : GoogleCredentials.getApplicationDefault(),
-              configuration.getFixedAttributes(),
-              configuration.getDeadline());
+          projectId, credentials, configuration.getFixedAttributes(), configuration.getDeadline());
     }
-    return TraceExporter.createWithStub(
-            projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
+    return TraceExporter.createWithClient(
+        projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
   }
 
-  static TraceExporter createWithStub(
-          String projectId,
-          TraceServiceClient traceServiceClient,
-          Map<String, AttributeValue> fixedAttributes) {
+  private static TraceExporter createWithClient(
+      String projectId,
+      TraceServiceClient traceServiceClient,
+      Map<String, AttributeValue> fixedAttributes) {
     return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
   }
 
-  static TraceExporter createWithCredentials(
-          String projectId,
-          Credentials credentials,
-          Map<String, AttributeValue> fixedAttributes,
-          Duration deadline)
-          throws IOException {
+  private static TraceExporter createWithCredentials(
+      String projectId,
+      Credentials credentials,
+      Map<String, AttributeValue> fixedAttributes,
+      Duration deadline)
+      throws IOException {
     TraceServiceSettings.Builder builder =
-            TraceServiceSettings.newBuilder()
-                    .setCredentialsProvider(
-                            FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
+        TraceServiceSettings.newBuilder()
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
     // We only use the batchWriteSpans API in this exporter.
     builder
-            .batchWriteSpansSettings()
-            .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
+        .batchWriteSpansSettings()
+        .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
     return new TraceExporter(
-            projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
+        projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
   }
 
   private TraceExporter(
-          String projectId,
-          TraceServiceClient traceServiceClient,
-          Map<String, AttributeValue> fixedAttributes) {
+      String projectId,
+      TraceServiceClient traceServiceClient,
+      Map<String, AttributeValue> fixedAttributes) {
     this.projectId = projectId;
     this.traceServiceClient = traceServiceClient;
     this.projectName = ProjectName.of(projectId);

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -43,7 +43,7 @@ public class TraceExporter implements SpanExporter {
     return new TraceExporter(projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
   }
 
-  private TraceExporter(String projectId, TraceServiceClient traceServiceClient,
+  public TraceExporter(String projectId, TraceServiceClient traceServiceClient,
       Map<String, AttributeValue> fixedAttributes) {
     this.projectId = projectId;
     this.traceServiceClient = traceServiceClient;

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -1,11 +1,22 @@
 package com.google.cloud.opentelemetry.trace;
 
+import static com.google.api.client.util.Preconditions.checkNotNull;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
 import com.google.cloud.trace.v2.TraceServiceClient;
+import com.google.cloud.trace.v2.TraceServiceSettings;
+import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.ProjectName;
 import com.google.devtools.cloudtrace.v2.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -18,7 +29,21 @@ public class TraceExporter implements SpanExporter {
   private final String projectId;
   private final Map<String, AttributeValue> fixedAttributes;
 
-  public TraceExporter(String projectId, TraceServiceClient traceServiceClient,
+  static TraceExporter createWithStub(String projectId, TraceServiceClient traceServiceClient,
+      Map<String, AttributeValue> fixedAttributes) {
+    return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
+  }
+
+  static TraceExporter createWithCredentials(String projectId, Credentials credentials,
+      Map<String, AttributeValue> fixedAttributes, Duration deadline) throws IOException {
+    TraceServiceSettings.Builder builder = TraceServiceSettings.newBuilder()
+        .setCredentialsProvider(FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
+    // We only use the batchWriteSpans API in this exporter.
+    builder.batchWriteSpansSettings().setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
+    return new TraceExporter(projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
+  }
+
+  private TraceExporter(String projectId, TraceServiceClient traceServiceClient,
       Map<String, AttributeValue> fixedAttributes) {
     this.projectId = projectId;
     this.traceServiceClient = traceServiceClient;
@@ -41,6 +66,5 @@ public class TraceExporter implements SpanExporter {
   public void shutdown() {
     throw new UnsupportedOperationException();
   }
-
 
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -23,76 +23,76 @@ import static com.google.api.client.util.Preconditions.checkNotNull;
 
 public class TraceExporter implements SpanExporter {
 
-    private final TraceServiceClient traceServiceClient;
-    private final ProjectName projectName;
-    private final String projectId;
-    private final Map<String, AttributeValue> fixedAttributes;
+  private final TraceServiceClient traceServiceClient;
+  private final ProjectName projectName;
+  private final String projectId;
+  private final Map<String, AttributeValue> fixedAttributes;
 
-    static TraceExporter createWithConfiguration(TraceConfiguration configuration)
-            throws IOException {
-        String projectId = configuration.getProjectId();
-        TraceServiceStub stub = configuration.getTraceServiceStub();
-        Credentials credentials = configuration.getCredentials();
-        // hello
-        if (stub == null) {
-            return TraceExporter.createWithCredentials(
-                    projectId,
-                    credentials != null ? credentials : GoogleCredentials.getApplicationDefault(),
-                    configuration.getFixedAttributes(),
-                    configuration.getDeadline());
-        }
-        return TraceExporter.createWithStub(
-                projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
+  static TraceExporter createWithConfiguration(TraceConfiguration configuration)
+          throws IOException {
+    String projectId = configuration.getProjectId();
+    TraceServiceStub stub = configuration.getTraceServiceStub();
+    Credentials credentials = configuration.getCredentials();
+
+    if (stub == null) {
+      return TraceExporter.createWithCredentials(
+              projectId,
+              credentials != null ? credentials : GoogleCredentials.getApplicationDefault(),
+              configuration.getFixedAttributes(),
+              configuration.getDeadline());
+    }
+    return TraceExporter.createWithStub(
+            projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
+  }
+
+  static TraceExporter createWithStub(
+          String projectId,
+          TraceServiceClient traceServiceClient,
+          Map<String, AttributeValue> fixedAttributes) {
+    return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
+  }
+
+  static TraceExporter createWithCredentials(
+          String projectId,
+          Credentials credentials,
+          Map<String, AttributeValue> fixedAttributes,
+          Duration deadline)
+          throws IOException {
+    TraceServiceSettings.Builder builder =
+            TraceServiceSettings.newBuilder()
+                    .setCredentialsProvider(
+                            FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
+    // We only use the batchWriteSpans API in this exporter.
+    builder
+            .batchWriteSpansSettings()
+            .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
+    return new TraceExporter(
+            projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
+  }
+
+  private TraceExporter(
+          String projectId,
+          TraceServiceClient traceServiceClient,
+          Map<String, AttributeValue> fixedAttributes) {
+    this.projectId = projectId;
+    this.traceServiceClient = traceServiceClient;
+    this.projectName = ProjectName.of(projectId);
+    this.fixedAttributes = fixedAttributes;
+  }
+
+  @Override
+  public ResultCode export(Collection<SpanData> spanDataList) {
+    List<Span> spans = new ArrayList<>(spanDataList.size());
+    for (SpanData spanData : spanDataList) {
+      spans.add(TraceTranslator.generateSpan(spanData, projectId, fixedAttributes));
     }
 
-    static TraceExporter createWithStub(
-            String projectId,
-            TraceServiceClient traceServiceClient,
-            Map<String, AttributeValue> fixedAttributes) {
-        return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
-    }
+    traceServiceClient.batchWriteSpans(projectName, spans);
+    return ResultCode.SUCCESS;
+  }
 
-    static TraceExporter createWithCredentials(
-            String projectId,
-            Credentials credentials,
-            Map<String, AttributeValue> fixedAttributes,
-            Duration deadline)
-            throws IOException {
-        TraceServiceSettings.Builder builder =
-                TraceServiceSettings.newBuilder()
-                        .setCredentialsProvider(
-                                FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
-        // We only use the batchWriteSpans API in this exporter.
-        builder
-                .batchWriteSpansSettings()
-                .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
-        return new TraceExporter(
-                projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
-    }
-
-    private TraceExporter(
-            String projectId,
-            TraceServiceClient traceServiceClient,
-            Map<String, AttributeValue> fixedAttributes) {
-        this.projectId = projectId;
-        this.traceServiceClient = traceServiceClient;
-        this.projectName = ProjectName.of(projectId);
-        this.fixedAttributes = fixedAttributes;
-    }
-
-    @Override
-    public ResultCode export(Collection<SpanData> spanDataList) {
-        List<Span> spans = new ArrayList<>(spanDataList.size());
-        for (SpanData spanData : spanDataList) {
-            spans.add(TraceTranslator.generateSpan(spanData, projectId, fixedAttributes));
-        }
-
-        traceServiceClient.batchWriteSpans(projectName, spans);
-        return ResultCode.SUCCESS;
-    }
-
-    @Override
-    public void shutdown() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void shutdown() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -1,14 +1,11 @@
 package com.google.cloud.opentelemetry.trace;
 
-import static com.google.api.client.util.Preconditions.checkNotNull;
-
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.ServiceOptions;
 import com.google.cloud.trace.v2.TraceServiceClient;
 import com.google.cloud.trace.v2.TraceServiceSettings;
-import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.cloud.trace.v2.stub.TraceServiceStub;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.ProjectName;
 import com.google.devtools.cloudtrace.v2.Span;
@@ -22,49 +19,80 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.api.client.util.Preconditions.checkNotNull;
+
 public class TraceExporter implements SpanExporter {
 
-  private final TraceServiceClient traceServiceClient;
-  private final ProjectName projectName;
-  private final String projectId;
-  private final Map<String, AttributeValue> fixedAttributes;
+    private final TraceServiceClient traceServiceClient;
+    private final ProjectName projectName;
+    private final String projectId;
+    private final Map<String, AttributeValue> fixedAttributes;
 
-  static TraceExporter createWithStub(String projectId, TraceServiceClient traceServiceClient,
-      Map<String, AttributeValue> fixedAttributes) {
-    return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
-  }
-
-  static TraceExporter createWithCredentials(String projectId, Credentials credentials,
-      Map<String, AttributeValue> fixedAttributes, Duration deadline) throws IOException {
-    TraceServiceSettings.Builder builder = TraceServiceSettings.newBuilder()
-        .setCredentialsProvider(FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
-    // We only use the batchWriteSpans API in this exporter.
-    builder.batchWriteSpansSettings().setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
-    return new TraceExporter(projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
-  }
-
-  public TraceExporter(String projectId, TraceServiceClient traceServiceClient,
-      Map<String, AttributeValue> fixedAttributes) {
-    this.projectId = projectId;
-    this.traceServiceClient = traceServiceClient;
-    this.projectName = ProjectName.of(projectId);
-    this.fixedAttributes = fixedAttributes;
-  }
-
-  @Override
-  public ResultCode export(Collection<SpanData> spanDataList) {
-    List<Span> spans = new ArrayList<>(spanDataList.size());
-    for (SpanData spanData : spanDataList) {
-      spans.add(TraceTranslator.generateSpan(spanData, projectId, fixedAttributes));
+    static TraceExporter createWithConfiguration(TraceConfiguration configuration)
+            throws IOException {
+        String projectId = configuration.getProjectId();
+        TraceServiceStub stub = configuration.getTraceServiceStub();
+        Credentials credentials = configuration.getCredentials();
+        // hello
+        if (stub == null) {
+            return TraceExporter.createWithCredentials(
+                    projectId,
+                    credentials != null ? credentials : GoogleCredentials.getApplicationDefault(),
+                    configuration.getFixedAttributes(),
+                    configuration.getDeadline());
+        }
+        return TraceExporter.createWithStub(
+                projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
     }
 
-    traceServiceClient.batchWriteSpans(projectName, spans);
-    return ResultCode.SUCCESS;
-  }
+    static TraceExporter createWithStub(
+            String projectId,
+            TraceServiceClient traceServiceClient,
+            Map<String, AttributeValue> fixedAttributes) {
+        return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
+    }
 
-  @Override
-  public void shutdown() {
-    throw new UnsupportedOperationException();
-  }
+    static TraceExporter createWithCredentials(
+            String projectId,
+            Credentials credentials,
+            Map<String, AttributeValue> fixedAttributes,
+            Duration deadline)
+            throws IOException {
+        TraceServiceSettings.Builder builder =
+                TraceServiceSettings.newBuilder()
+                        .setCredentialsProvider(
+                                FixedCredentialsProvider.create(checkNotNull(credentials, "credentials")));
+        // We only use the batchWriteSpans API in this exporter.
+        builder
+                .batchWriteSpansSettings()
+                .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
+        return new TraceExporter(
+                projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
+    }
 
+    private TraceExporter(
+            String projectId,
+            TraceServiceClient traceServiceClient,
+            Map<String, AttributeValue> fixedAttributes) {
+        this.projectId = projectId;
+        this.traceServiceClient = traceServiceClient;
+        this.projectName = ProjectName.of(projectId);
+        this.fixedAttributes = fixedAttributes;
+    }
+
+    @Override
+    public ResultCode export(Collection<SpanData> spanDataList) {
+        List<Span> spans = new ArrayList<>(spanDataList.size());
+        for (SpanData spanData : spanDataList) {
+            spans.add(TraceTranslator.generateSpan(spanData, projectId, fixedAttributes));
+        }
+
+        traceServiceClient.batchWriteSpans(projectName, spans);
+        return ResultCode.SUCCESS;
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
@@ -14,7 +15,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.time.Duration;
 import java.util.Map;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
@@ -29,9 +29,6 @@ public class TraceConfigurationTest {
     private static final String PROJECT_ID = "project";
     private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
     private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void defaultConfiguration() {
@@ -64,16 +61,14 @@ public class TraceConfigurationTest {
     @Test
     public void disallowNullProjectId() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder();
-        thrown.expect(NullPointerException.class);
-        builder.setProjectId(null);
+        assertThrows(NullPointerException.class, () -> builder.setProjectId(null));
     }
 
     @Test
     public void disallowEmptyProjectId() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder();
         builder.setProjectId("");
-        thrown.expect(IllegalArgumentException.class);
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
     @Test
@@ -88,8 +83,7 @@ public class TraceConfigurationTest {
     @Test
     public void disallowNullFixedAttributes() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
-        thrown.expect(NullPointerException.class);
-        builder.setFixedAttributes(null);
+        assertThrows(NullPointerException.class, () -> builder.setFixedAttributes(null));
     }
 
     @Test
@@ -98,8 +92,7 @@ public class TraceConfigurationTest {
         Map<String, AttributeValue> attributes = Collections.singletonMap(null,
                 AttributeValue.stringAttributeValue("val"));
         builder.setFixedAttributes(attributes);
-        thrown.expect(NullPointerException.class);
-        builder.build();
+        assertThrows(NullPointerException.class, () -> builder.build());
     }
 
     @Test
@@ -107,24 +100,21 @@ public class TraceConfigurationTest {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
         builder.setFixedAttributes(attributes);
-        thrown.expect(NullPointerException.class);
-        builder.build();
+        assertThrows(NullPointerException.class, () -> builder.build());
     }
 
     @Test
     public void disallowZeroDuration() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         builder.setDeadline(TraceConfiguration.Builder.ZERO);
-        thrown.expect(IllegalArgumentException.class);
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
     @Test
     public void disallowNegativeDuration() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         builder.setDeadline(NEG_ONE_MINUTE);
-        thrown.expect(IllegalArgumentException.class);
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -16,14 +16,12 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
-/**
- * Unit tests for {@link TraceConfiguration}.
- */
+/** Unit tests for {@link TraceConfiguration}. */
 @RunWith(JUnit4.class)
 public class TraceConfigurationTest {
 
-  private static final Credentials FAKE_CREDENTIALS = GoogleCredentials.newBuilder()
-          .setAccessToken(new AccessToken("fake", new Date(100))).build();
+  private static final Credentials FAKE_CREDENTIALS =
+      GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
   private static final String PROJECT_ID = "project";
   private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
   private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
@@ -42,12 +40,17 @@ public class TraceConfigurationTest {
 
   @Test
   public void setAllConfigurationFields() {
-    Map<String, AttributeValue> attributes = Collections.singletonMap("key",
-            AttributeValue.newBuilder().setBoolValue(true).build());
+    Map<String, AttributeValue> attributes =
+        Collections.singletonMap("key", AttributeValue.newBuilder().setBoolValue(true).build());
 
     // set all the fields different from their default values
-    TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
-            .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
+    TraceConfiguration configuration =
+        TraceConfiguration.builder()
+            .setCredentials(FAKE_CREDENTIALS)
+            .setProjectId(PROJECT_ID)
+            .setFixedAttributes(attributes)
+            .setDeadline(ONE_MINUTE)
+            .build();
 
     // make sure the changes are reflected
     assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
@@ -94,8 +97,8 @@ public class TraceConfigurationTest {
   public void disallowNullFixedAttributeKey() {
     TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-    Map<String, AttributeValue> attributes = Collections.singletonMap(null,
-            AttributeValue.newBuilder().setBoolValue(true).build());
+    Map<String, AttributeValue> attributes =
+        Collections.singletonMap(null, AttributeValue.newBuilder().setBoolValue(true).build());
     builder.setFixedAttributes(attributes);
 
     assertThrows(NullPointerException.class, () -> builder.build());
@@ -128,5 +131,4 @@ public class TraceConfigurationTest {
 
     assertThrows(IllegalArgumentException.class, () -> builder.build());
   }
-
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -11,15 +11,19 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
+
 import java.util.Collections;
 import java.util.Date;
 import java.time.Duration;
 import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TraceConfiguration}. */
+/**
+ * Unit tests for {@link TraceConfiguration}.
+ */
 @RunWith(JUnit4.class)
 public class TraceConfigurationTest {
 
@@ -31,13 +35,9 @@ public class TraceConfigurationTest {
 
     @Test
     public void defaultConfiguration() {
-        TraceConfiguration configuration;
-        try {
-            configuration = TraceConfiguration.builder().build();
-        } catch (Exception e) {
-            // Some test hosts may not have cloud project ID set up.
-            configuration = TraceConfiguration.builder().setProjectId("test").build();
-        }
+        // Some test hosts may not have cloud project ID set up, so setting it explicitly
+        TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
+
         assertNull(configuration.getCredentials());
         assertNotNull(configuration.getProjectId());
         assertNull(configuration.getTraceServiceStub());
@@ -46,11 +46,15 @@ public class TraceConfigurationTest {
     }
 
     @Test
-    public void updateAll() {
+    public void setAllConfigurationFields() {
         Map<String, AttributeValue> attributes = Collections.singletonMap("key",
                 AttributeValue.newBuilder().setBoolValue(true).build());
+
+        // set all the fields different from their default values
         TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
                 .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
+
+        // make sure the changes are reflected
         assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
         assertEquals(PROJECT_ID, configuration.getProjectId());
         assertEquals(attributes, configuration.getFixedAttributes());
@@ -60,21 +64,26 @@ public class TraceConfigurationTest {
     @Test
     public void disallowNullProjectId() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder();
+
         assertThrows(NullPointerException.class, () -> builder.setProjectId(null));
     }
 
     @Test
     public void disallowEmptyProjectId() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder();
+
         builder.setProjectId("");
+
         assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
     @Test
     public void allowToUseDefaultProjectId() {
         String defaultProjectId = ServiceOptions.getDefaultProjectId();
+        // some test providers might not have project IDs set up
         if (defaultProjectId != null) {
             TraceConfiguration configuration = TraceConfiguration.builder().build();
+
             assertEquals(defaultProjectId, configuration.getProjectId());
         }
     }
@@ -82,37 +91,46 @@ public class TraceConfigurationTest {
     @Test
     public void disallowNullFixedAttributes() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+
         assertThrows(NullPointerException.class, () -> builder.setFixedAttributes(null));
     }
 
     @Test
     public void disallowNullFixedAttributeKey() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+
         Map<String, AttributeValue> attributes = Collections.singletonMap(null,
                 AttributeValue.newBuilder().setBoolValue(true).build());
         builder.setFixedAttributes(attributes);
+
         assertThrows(NullPointerException.class, () -> builder.build());
     }
 
     @Test
     public void disallowNullFixedAttributeValue() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+
         Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
         builder.setFixedAttributes(attributes);
+
         assertThrows(NullPointerException.class, () -> builder.build());
     }
 
     @Test
     public void disallowZeroDuration() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+
         builder.setDeadline(TraceConfiguration.Builder.ZERO);
+
         assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
     @Test
     public void disallowNegativeDuration() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+
         builder.setDeadline(NEG_ONE_MINUTE);
+
         assertThrows(IllegalArgumentException.class, () -> builder.build());
     }
 

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -1,0 +1,140 @@
+package com.google.cloud.opentelemetry.trace;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
+import java.time.Duration;
+import io.opentelemetry.common.AttributeValue;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TraceConfiguration}. */
+@RunWith(JUnit4.class)
+public class TraceConfigurationTest {
+
+    private static final Credentials FAKE_CREDENTIALS =
+            GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
+    private static final String PROJECT_ID = "project";
+    private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
+    private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
+
+    @Rule public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void defaultConfiguration() {
+        TraceConfiguration configuration;
+        try {
+            configuration = TraceConfiguration.builder().build();
+        } catch (Exception e) {
+            // Some test hosts may not have cloud project ID set up.
+            configuration = TraceConfiguration.builder().setProjectId("test").build();
+        }
+        assertNull(configuration.getCredentials());
+        assertNotNull(configuration.getProjectId());
+        assertNull(configuration.getTraceServiceStub());
+        assertTrue(configuration.getFixedAttributes().isEmpty());
+        assertEquals(configuration.getDeadline(), TraceConfiguration.DEFAULT_DEADLINE);
+    }
+
+    @Test
+    public void updateAll() {
+        Map<String, AttributeValue> attributes =
+                Collections.singletonMap("key", AttributeValue.stringAttributeValue("val"));
+        TraceConfiguration configuration =
+                TraceConfiguration.builder()
+                        .setCredentials(FAKE_CREDENTIALS)
+                        .setProjectId(PROJECT_ID)
+                        .setFixedAttributes(attributes)
+                        .setDeadline(ONE_MINUTE)
+                        .build();
+        assertEquals(configuration.getCredentials(), FAKE_CREDENTIALS);
+        assertEquals(configuration.getProjectId(), PROJECT_ID);
+        assertEquals(configuration.getFixedAttributes(), attributes);
+        assertEquals(configuration.getDeadline(), ONE_MINUTE);
+    }
+
+    @Test
+    public void disallowNullProjectId() {
+        TraceConfiguration.Builder builder = TraceConfiguration.builder();
+        thrown.expect(NullPointerException.class);
+        builder.setProjectId(null);
+    }
+
+    @Test
+    public void disallowEmptyProjectId() {
+        TraceConfiguration.Builder builder = TraceConfiguration.builder();
+        builder.setProjectId("");
+        thrown.expect(IllegalArgumentException.class);
+        builder.build();
+    }
+
+    @Test
+    public void allowToUseDefaultProjectId() {
+        String defaultProjectId = ServiceOptions.getDefaultProjectId();
+        if (defaultProjectId != null) {
+            TraceConfiguration configuration = TraceConfiguration.builder().build();
+            assertEquals(configuration.getProjectId(), defaultProjectId);
+        }
+    }
+
+    @Test
+    public void disallowNullFixedAttributes() {
+        TraceConfiguration.Builder builder =
+                TraceConfiguration.builder().setProjectId("test");
+        thrown.expect(NullPointerException.class);
+        builder.setFixedAttributes(null);
+    }
+
+    @Test
+    public void disallowNullFixedAttributeKey() {
+        TraceConfiguration.Builder builder =
+                TraceConfiguration.builder().setProjectId("test");
+        Map<String, AttributeValue> attributes =
+                Collections.singletonMap(null, AttributeValue.stringAttributeValue("val"));
+        builder.setFixedAttributes(attributes);
+        thrown.expect(NullPointerException.class);
+        builder.build();
+    }
+
+    @Test
+    public void disallowNullFixedAttributeValue() {
+        TraceConfiguration.Builder builder =
+                TraceConfiguration.builder().setProjectId("test");
+        Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
+        builder.setFixedAttributes(attributes);
+        thrown.expect(NullPointerException.class);
+        builder.build();
+    }
+
+    @Test
+    public void disallowZeroDuration() {
+        TraceConfiguration.Builder builder =
+                TraceConfiguration.builder().setProjectId("test");
+        builder.setDeadline(TraceConfiguration.Builder.ZERO);
+        thrown.expect(IllegalArgumentException.class);
+        builder.build();
+    }
+
+    @Test
+    public void disallowNegativeDuration() {
+        TraceConfiguration.Builder builder =
+                TraceConfiguration.builder().setProjectId("test");
+        builder.setDeadline(NEG_ONE_MINUTE);
+        thrown.expect(IllegalArgumentException.class);
+        builder.build();
+    }
+
+}

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -1,25 +1,20 @@
 package com.google.cloud.opentelemetry.trace;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
-
-import java.util.Collections;
-import java.util.Date;
-import java.time.Duration;
-import java.util.Map;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link TraceConfiguration}.
@@ -27,111 +22,111 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TraceConfigurationTest {
 
-    private static final Credentials FAKE_CREDENTIALS = GoogleCredentials.newBuilder()
-            .setAccessToken(new AccessToken("fake", new Date(100))).build();
-    private static final String PROJECT_ID = "project";
-    private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
-    private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
+  private static final Credentials FAKE_CREDENTIALS = GoogleCredentials.newBuilder()
+          .setAccessToken(new AccessToken("fake", new Date(100))).build();
+  private static final String PROJECT_ID = "project";
+  private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
+  private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
 
-    @Test
-    public void defaultConfiguration() {
-        // Some test hosts may not have cloud project ID set up, so setting it explicitly
-        TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
+  @Test
+  public void defaultConfiguration() {
+    // Some test hosts may not have cloud project ID set up, so setting it explicitly
+    TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
 
-        assertNull(configuration.getCredentials());
-        assertNotNull(configuration.getProjectId());
-        assertNull(configuration.getTraceServiceStub());
-        assertTrue(configuration.getFixedAttributes().isEmpty());
-        assertEquals(TraceConfiguration.DEFAULT_DEADLINE, configuration.getDeadline());
+    assertNull(configuration.getCredentials());
+    assertNotNull(configuration.getProjectId());
+    assertNull(configuration.getTraceServiceStub());
+    assertTrue(configuration.getFixedAttributes().isEmpty());
+    assertEquals(TraceConfiguration.DEFAULT_DEADLINE, configuration.getDeadline());
+  }
+
+  @Test
+  public void setAllConfigurationFields() {
+    Map<String, AttributeValue> attributes = Collections.singletonMap("key",
+            AttributeValue.newBuilder().setBoolValue(true).build());
+
+    // set all the fields different from their default values
+    TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
+            .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
+
+    // make sure the changes are reflected
+    assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
+    assertEquals(PROJECT_ID, configuration.getProjectId());
+    assertEquals(attributes, configuration.getFixedAttributes());
+    assertEquals(ONE_MINUTE, configuration.getDeadline());
+  }
+
+  @Test
+  public void disallowNullProjectId() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder();
+
+    assertThrows(NullPointerException.class, () -> builder.setProjectId(null));
+  }
+
+  @Test
+  public void disallowEmptyProjectId() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder();
+
+    builder.setProjectId("");
+
+    assertThrows(IllegalArgumentException.class, () -> builder.build());
+  }
+
+  @Test
+  public void allowToUseDefaultProjectId() {
+    String defaultProjectId = ServiceOptions.getDefaultProjectId();
+    // some test providers might not have project IDs set up
+    if (defaultProjectId != null) {
+      TraceConfiguration configuration = TraceConfiguration.builder().build();
+
+      assertEquals(defaultProjectId, configuration.getProjectId());
     }
+  }
 
-    @Test
-    public void setAllConfigurationFields() {
-        Map<String, AttributeValue> attributes = Collections.singletonMap("key",
-                AttributeValue.newBuilder().setBoolValue(true).build());
+  @Test
+  public void disallowNullFixedAttributes() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-        // set all the fields different from their default values
-        TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
-                .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
+    assertThrows(NullPointerException.class, () -> builder.setFixedAttributes(null));
+  }
 
-        // make sure the changes are reflected
-        assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
-        assertEquals(PROJECT_ID, configuration.getProjectId());
-        assertEquals(attributes, configuration.getFixedAttributes());
-        assertEquals(ONE_MINUTE, configuration.getDeadline());
-    }
+  @Test
+  public void disallowNullFixedAttributeKey() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-    @Test
-    public void disallowNullProjectId() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder();
+    Map<String, AttributeValue> attributes = Collections.singletonMap(null,
+            AttributeValue.newBuilder().setBoolValue(true).build());
+    builder.setFixedAttributes(attributes);
 
-        assertThrows(NullPointerException.class, () -> builder.setProjectId(null));
-    }
+    assertThrows(NullPointerException.class, () -> builder.build());
+  }
 
-    @Test
-    public void disallowEmptyProjectId() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder();
+  @Test
+  public void disallowNullFixedAttributeValue() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-        builder.setProjectId("");
+    Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
+    builder.setFixedAttributes(attributes);
 
-        assertThrows(IllegalArgumentException.class, () -> builder.build());
-    }
+    assertThrows(NullPointerException.class, () -> builder.build());
+  }
 
-    @Test
-    public void allowToUseDefaultProjectId() {
-        String defaultProjectId = ServiceOptions.getDefaultProjectId();
-        // some test providers might not have project IDs set up
-        if (defaultProjectId != null) {
-            TraceConfiguration configuration = TraceConfiguration.builder().build();
+  @Test
+  public void disallowZeroDuration() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-            assertEquals(defaultProjectId, configuration.getProjectId());
-        }
-    }
+    builder.setDeadline(TraceConfiguration.Builder.ZERO);
 
-    @Test
-    public void disallowNullFixedAttributes() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+    assertThrows(IllegalArgumentException.class, () -> builder.build());
+  }
 
-        assertThrows(NullPointerException.class, () -> builder.setFixedAttributes(null));
-    }
+  @Test
+  public void disallowNegativeDuration() {
+    TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
 
-    @Test
-    public void disallowNullFixedAttributeKey() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+    builder.setDeadline(NEG_ONE_MINUTE);
 
-        Map<String, AttributeValue> attributes = Collections.singletonMap(null,
-                AttributeValue.newBuilder().setBoolValue(true).build());
-        builder.setFixedAttributes(attributes);
-
-        assertThrows(NullPointerException.class, () -> builder.build());
-    }
-
-    @Test
-    public void disallowNullFixedAttributeValue() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
-
-        Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
-        builder.setFixedAttributes(attributes);
-
-        assertThrows(NullPointerException.class, () -> builder.build());
-    }
-
-    @Test
-    public void disallowZeroDuration() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
-
-        builder.setDeadline(TraceConfiguration.Builder.ZERO);
-
-        assertThrows(IllegalArgumentException.class, () -> builder.build());
-    }
-
-    @Test
-    public void disallowNegativeDuration() {
-        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
-
-        builder.setDeadline(NEG_ONE_MINUTE);
-
-        assertThrows(IllegalArgumentException.class, () -> builder.build());
-    }
+    assertThrows(IllegalArgumentException.class, () -> builder.build());
+  }
 
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -5,15 +5,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-import java.time.Duration;
 import io.opentelemetry.common.AttributeValue;
 import java.util.Collections;
 import java.util.Date;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,13 +24,14 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TraceConfigurationTest {
 
-    private static final Credentials FAKE_CREDENTIALS =
-            GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
+    private static final Credentials FAKE_CREDENTIALS = GoogleCredentials.newBuilder()
+            .setAccessToken(new AccessToken("fake", new Date(100))).build();
     private static final String PROJECT_ID = "project";
     private static final Duration ONE_MINUTE = Duration.ofSeconds(60, 0);
     private static final Duration NEG_ONE_MINUTE = Duration.ofSeconds(-60, 0);
 
-    @Rule public final ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void defaultConfiguration() {
@@ -51,15 +51,10 @@ public class TraceConfigurationTest {
 
     @Test
     public void updateAll() {
-        Map<String, AttributeValue> attributes =
-                Collections.singletonMap("key", AttributeValue.stringAttributeValue("val"));
-        TraceConfiguration configuration =
-                TraceConfiguration.builder()
-                        .setCredentials(FAKE_CREDENTIALS)
-                        .setProjectId(PROJECT_ID)
-                        .setFixedAttributes(attributes)
-                        .setDeadline(ONE_MINUTE)
-                        .build();
+        Map<String, AttributeValue> attributes = Collections.singletonMap("key",
+                AttributeValue.stringAttributeValue("val"));
+        TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
+                .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
         assertEquals(configuration.getCredentials(), FAKE_CREDENTIALS);
         assertEquals(configuration.getProjectId(), PROJECT_ID);
         assertEquals(configuration.getFixedAttributes(), attributes);
@@ -92,18 +87,16 @@ public class TraceConfigurationTest {
 
     @Test
     public void disallowNullFixedAttributes() {
-        TraceConfiguration.Builder builder =
-                TraceConfiguration.builder().setProjectId("test");
+        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         thrown.expect(NullPointerException.class);
         builder.setFixedAttributes(null);
     }
 
     @Test
     public void disallowNullFixedAttributeKey() {
-        TraceConfiguration.Builder builder =
-                TraceConfiguration.builder().setProjectId("test");
-        Map<String, AttributeValue> attributes =
-                Collections.singletonMap(null, AttributeValue.stringAttributeValue("val"));
+        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
+        Map<String, AttributeValue> attributes = Collections.singletonMap(null,
+                AttributeValue.stringAttributeValue("val"));
         builder.setFixedAttributes(attributes);
         thrown.expect(NullPointerException.class);
         builder.build();
@@ -111,8 +104,7 @@ public class TraceConfigurationTest {
 
     @Test
     public void disallowNullFixedAttributeValue() {
-        TraceConfiguration.Builder builder =
-                TraceConfiguration.builder().setProjectId("test");
+        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
         builder.setFixedAttributes(attributes);
         thrown.expect(NullPointerException.class);
@@ -121,8 +113,7 @@ public class TraceConfigurationTest {
 
     @Test
     public void disallowZeroDuration() {
-        TraceConfiguration.Builder builder =
-                TraceConfiguration.builder().setProjectId("test");
+        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         builder.setDeadline(TraceConfiguration.Builder.ZERO);
         thrown.expect(IllegalArgumentException.class);
         builder.build();
@@ -130,8 +121,7 @@ public class TraceConfigurationTest {
 
     @Test
     public void disallowNegativeDuration() {
-        TraceConfiguration.Builder builder =
-                TraceConfiguration.builder().setProjectId("test");
+        TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         builder.setDeadline(NEG_ONE_MINUTE);
         thrown.expect(IllegalArgumentException.class);
         builder.build();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -10,13 +10,12 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-import io.opentelemetry.common.AttributeValue;
+import com.google.devtools.cloudtrace.v2.AttributeValue;
 import java.util.Collections;
 import java.util.Date;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -43,19 +42,19 @@ public class TraceConfigurationTest {
         assertNotNull(configuration.getProjectId());
         assertNull(configuration.getTraceServiceStub());
         assertTrue(configuration.getFixedAttributes().isEmpty());
-        assertEquals(configuration.getDeadline(), TraceConfiguration.DEFAULT_DEADLINE);
+        assertEquals(TraceConfiguration.DEFAULT_DEADLINE, configuration.getDeadline());
     }
 
     @Test
     public void updateAll() {
         Map<String, AttributeValue> attributes = Collections.singletonMap("key",
-                AttributeValue.stringAttributeValue("val"));
+                AttributeValue.newBuilder().setBoolValue(true).build());
         TraceConfiguration configuration = TraceConfiguration.builder().setCredentials(FAKE_CREDENTIALS)
                 .setProjectId(PROJECT_ID).setFixedAttributes(attributes).setDeadline(ONE_MINUTE).build();
-        assertEquals(configuration.getCredentials(), FAKE_CREDENTIALS);
-        assertEquals(configuration.getProjectId(), PROJECT_ID);
-        assertEquals(configuration.getFixedAttributes(), attributes);
-        assertEquals(configuration.getDeadline(), ONE_MINUTE);
+        assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
+        assertEquals(PROJECT_ID, configuration.getProjectId());
+        assertEquals(attributes, configuration.getFixedAttributes());
+        assertEquals(ONE_MINUTE, configuration.getDeadline());
     }
 
     @Test
@@ -76,7 +75,7 @@ public class TraceConfigurationTest {
         String defaultProjectId = ServiceOptions.getDefaultProjectId();
         if (defaultProjectId != null) {
             TraceConfiguration configuration = TraceConfiguration.builder().build();
-            assertEquals(configuration.getProjectId(), defaultProjectId);
+            assertEquals(defaultProjectId, configuration.getProjectId());
         }
     }
 
@@ -90,7 +89,7 @@ public class TraceConfigurationTest {
     public void disallowNullFixedAttributeKey() {
         TraceConfiguration.Builder builder = TraceConfiguration.builder().setProjectId("test");
         Map<String, AttributeValue> attributes = Collections.singletonMap(null,
-                AttributeValue.stringAttributeValue("val"));
+                AttributeValue.newBuilder().setBoolValue(true).build());
         builder.setFixedAttributes(attributes);
         assertThrows(NullPointerException.class, () -> builder.build());
     }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -1,22 +1,25 @@
 package com.google.cloud.opentelemetry.trace;
 
-import com.google.devtools.cloudtrace.v2.AttributeValue;
 import static org.junit.Assert.assertNotNull;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import java.util.Map;
-import java.util.HashMap;
+
+import java.io.IOException;
+
 import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class TraceExporterTest {
 
-  private final String PROJECT_ID = "project";
-  private final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>();
+    @Test
+    public void createWithConfiguration() {
+        TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
+        try {
+            TraceExporter exporter = TraceExporter.createWithConfiguration(configuration);
 
-  @Test
-  public void exporterConstructorTest() {
-    final TraceExporter exporter = new TraceExporter(PROJECT_ID, null, FIXED_ATTRIBUTES);
-    assertNotNull(exporter);
-  }
+            assertNotNull(exporter);
+        } catch (IOException e) {
+        }
+    }
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -1,25 +1,24 @@
 package com.google.cloud.opentelemetry.trace;
 
-import static org.junit.Assert.assertNotNull;
-
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(JUnit4.class)
 public class TraceExporterTest {
 
-    @Test
-    public void createWithConfiguration() {
-        TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
-        try {
-            TraceExporter exporter = TraceExporter.createWithConfiguration(configuration);
+  @Test
+  public void createWithConfiguration() {
+    TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
+    try {
+      TraceExporter exporter = TraceExporter.createWithConfiguration(configuration);
 
-            assertNotNull(exporter);
-        } catch (IOException e) {
-        }
+      assertNotNull(exporter);
+    } catch (IOException e) {
     }
+  }
 }


### PR DESCRIPTION
# Context
Opencensus had a `StackdriverTraceConfiguration` file. This made it easy for customers to use the exporter while taking information from environment variables like project ID automatically. In addition, it abstracted away the details of making your own TraceServiceClient, which was not very clear how to do.

# Solution
I created an abstract class which is generated using the @AutoValue annotation. This configuration should be able to be used to create a configuration, which will be able to be passed as an argument to the TraceExporter by customers.
The configuration contains many of the attributes important to customers, such as createTraceServiceStub.

In the future this will be integrated with the actual TraceExporter class for customers to make exporters.

# Test plan
```sh
$ gradle test

BUILD SUCCESSFUL in 1s
3 actionable tasks: 3 up-to-date
```

