### PR TITLE
Add Unit Test with mock TraceServiceClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
+        jcenter()
         mavenCentral()
         mavenLocal()
         maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
@@ -15,6 +16,7 @@ subprojects {
 
     ext {
         googleCloudVersion = '1.0.2'
+        mockitoVersion = '2.+'
         openTelemetryVersion = '0.3.0'
         junitVersion = '4.13';
 
@@ -24,7 +26,9 @@ subprojects {
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
         ]
         testLibraries = [
-                junit:"junit:junit:${junitVersion}"
+                junit:"junit:junit:${junitVersion}",
+                mockito:"org.mockito:mockito-core:${mockitoVersion}",
+
         ]
     }
 }

--- a/exporters/trace/README.md
+++ b/exporters/trace/README.md
@@ -28,7 +28,8 @@
   Start tracing and collecting SpanData.  
   Spans can be created by importing and using global `opentelemetry-java` API packages, for example:  
   ```java
-  Span span = this.tracer.spanBuilder("operation name").startSpan();
+  String operationName = "receive"; //or whatever other operation
+  Span span = this.tracer.spanBuilder(operationName).startSpan();
   ```
   To export these spans, configure the trace provider with the exporter:
   ```java

--- a/exporters/trace/README.md
+++ b/exporters/trace/README.md
@@ -12,7 +12,7 @@
 ## Usage
   If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instructions in Authentication.  
     
-  The TraceExporter constructor takes in three parameters: String for projectId, TraceServiceClient to create a traceServiceClient instance, and Map<String, AttributeValue> for the fixed attributes of a span.  
+  The TraceExporter constructor takes in three parameters: `projectId: String` for your GCP project ID, `traceServiceClient: TraceServiceClient` for the trace service client to eventually batch write spans, and `fixedAttributes: Map<String, AttributeValue>` for the fixed attributes of a span.  
   So, we need to import the following: 
   ```java
   import com.google.cloud.trace.v2.TraceServiceClient;
@@ -23,25 +23,28 @@
   Declare and initialize the variables that will be used in the constructor parameters.  
   Then, we can create a TraceExporter with, for example:
   ```java
-  TraceExporter exporter = new TraceExporter(projectId, traceServiceClient, fixedAttributes);
+  TraceExporter javaTraceExporter = new TraceExporter(projectId, traceServiceClient, fixedAttributes);
   ```
-  Start tracing and collecting SpanData. To export these spans, use the export method, where spanDataList is a Collection of SpanData already collected:
+  Start tracing and collecting SpanData.  
+  Spans can be created by importing and using global `opentelemetry-java` API packages, for example:  
   ```java
-  exporter.export(spanDataList)
+  Span span = this.tracer.spanBuilder("operation name").startSpan();
+  ```
+  To export these spans, configure the trace provider with the exporter:
+  ```java
+  OpenTelemetrySdk.getTracerProvider().addSpanProcessor(SimpleSpanProcessor.newBuilder(this.javaTraceExporter).build());
   ```
 
 ## Authentication
   This exporter uses <a href="https://github.com/googleapis/google-cloud-java">google-cloud-java</a>, for details about how to configure the authentication see <a href="https://github.com/googleapis/google-cloud-java#authentication">here</a>.  
     
-  In the case that there are problems creating a service account key, make sure that the constraints/iam.disableServiceAccountKeyCreation boolean variable is set to false. This can be edited on Google Cloud by clicking on Navigation Menu -> IAM & Admin -> Organization Policies -> Disable Service Account Key Creation -> Edit  
+  In the case that there are problems creating a service account key, make sure that the **constraints/iam.disableServiceAccountKeyCreation** boolean variable is set to false. This can be edited on Google Cloud by clicking on Navigation Menu -> IAM & Admin -> Organization Policies -> Disable Service Account Key Creation -> Edit  
     
-  If you are unable to edit this variable due to lack of permission, you can authenticate by running "gcloud auth application-default login" in the command line.
+  If you are unable to edit this variable due to lack of permission, you can authenticate by running `gcloud auth application-default login` in the command line.
   
 
 ## Useful Links
   - For more information on OpenTelemetry, visit: https://opentelemetry.io/  
-  - For more about OpenTelemetry Java, visit: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java  
+  - For more about OpenTelemetry Java, visit: https://github.com/open-telemetry/opentelemetry-java  
   - Learn more about Google Cloud Trace at https://cloud.google.com/trace
   
-  
-

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,10 +1,9 @@
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
-repositories { jcenter() }
 dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
     testImplementation(testLibraries.junit)
-    testCompile "org.mockito:mockito-core:2.+"
+    testCompile(testLibraries.mockito)
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,8 +1,10 @@
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
+repositories { jcenter() }
 dependencies {
     api(libraries.opentelemetry_api)
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_trace)
     testImplementation(testLibraries.junit)
+    testCompile "org.mockito:mockito-core:2.+"
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -9,20 +9,26 @@ import com.google.protobuf.BoolValue;
 import com.google.rpc.Status;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.trace.*;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.SpanContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.eq;
 
 @RunWith(JUnit4.class)
 public class EndToEndTest {

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -74,7 +74,7 @@ public class EndToEndTest {
   private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
 
 
-  // Some test cases, for example. Since the core function of this exporter is export(), we may focus on testing that.
+  // Some test cases. Since the core function of this exporter is export(), we may focus on testing that.
 
   @Test
   public void export(){
@@ -126,7 +126,7 @@ public class EndToEndTest {
             .when(mockTraceServiceClient).batchWriteSpans(eq(PROJECT_ID), anyList());
 
     // Invokes export();
-    assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
+    assertEquals(SpanExporter.ResultCode.SUCCESS, exporter.export(spanDataList));
 
     // Make sure that the parameters passed to batchWriteSpans() are what we expect them to be
     verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -32,122 +32,120 @@ import static org.mockito.Mockito.eq;
 
 @RunWith(JUnit4.class)
 public class EndToEndTest {
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
 
-    // Creating a mock TraceServiceClient so that batchWriteSpans() method won't actually be called
-    TraceServiceClient mockTraceServiceClient = Mockito.mock(TraceServiceClient.class);
+  // Creating a mock TraceServiceClient so that batchWriteSpans() method won't actually be called
+  TraceServiceClient mockTraceServiceClient = Mockito.mock(TraceServiceClient.class);
 
-    private TraceExporter exporter;
+  private TraceExporter exporter;
 
-    private static final String PROJECT_ID = "project-id";
-    private static final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>();
-    private static final TraceId TRACE_ID = new TraceId(321, 123);
-    private static final SpanId SPAN_ID = new SpanId(12345);
-    private static final SpanId PARENT_SPAN_ID = new SpanId(54321);
-    // private static final SpanId PARENT_SPAN_ID = SpanId.fromLowerBase16("71da8d631536f5f1", 0);
-    private static final TraceFlags TRACE_FLAGS = TraceFlags.builder().build();
-    private static final TraceState TRACE_STATE = TraceState.builder().build();
-    private static final SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TRACE_FLAGS, TRACE_STATE);
-    private static final String SPAN_NAME = "MySpanName";
-    private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
-    private static final long START_SECONDS = TimeUnit.NANOSECONDS.toSeconds(START_EPOCH_NANOS);
-    private static final int START_NANOS = (int) (START_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(START_SECONDS));
-    private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
-    private static final long END_SECONDS = TimeUnit.NANOSECONDS.toSeconds(END_EPOCH_NANOS);
-    private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
-    private static final String SERVER_PREFIX = "Recv.";
-    private static final String AGENT_LABEL_KEY = "g.co/agent";
-    private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.3.0";
-    private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
-    private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
-            .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
-    private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()
-            .setDroppedAttributesCount(0)
-            .putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE)
+  private static final String PROJECT_ID = "project-id";
+  private static final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>();
+  private static final TraceId TRACE_ID = new TraceId(321, 123);
+  private static final SpanId SPAN_ID = new SpanId(12345);
+  private static final SpanId PARENT_SPAN_ID = new SpanId(54321);
+  private static final TraceFlags TRACE_FLAGS = TraceFlags.builder().build();
+  private static final TraceState TRACE_STATE = TraceState.builder().build();
+  private static final SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TRACE_FLAGS, TRACE_STATE);
+  private static final String SPAN_NAME = "MySpanName";
+  private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
+  private static final long START_SECONDS = TimeUnit.NANOSECONDS.toSeconds(START_EPOCH_NANOS);
+  private static final int START_NANOS = (int) (START_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(START_SECONDS));
+  private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
+  private static final long END_SECONDS = TimeUnit.NANOSECONDS.toSeconds(END_EPOCH_NANOS);
+  private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
+  private static final String SERVER_PREFIX = "Recv.";
+  private static final String AGENT_LABEL_KEY = "g.co/agent";
+  private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.3.0";
+  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
+  private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
+          .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
+  private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()
+          .setDroppedAttributesCount(0)
+          .putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE)
+          .build();
+  private static final Span.TimeEvents TIME_EVENTS = Span.TimeEvents.newBuilder().build();
+  private static final io.opentelemetry.trace.Status SPAN_DATA_STATUS = io.opentelemetry.trace.Status.OK;
+  private static final Status SPAN_STATUS = Status.newBuilder().setCode(SPAN_DATA_STATUS.getCanonicalCode().value())
+          .build();
+  private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
+
+
+  // Some test cases, for example. Since the core function of this exporter is export(), we may focus on testing that.
+
+  @Test
+  public void export(){
+    // Constructs an exporter instance.
+    exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+    Collection<SpanData> spanDataList = new ArrayList<>();
+
+    SpanData spanDataOne = SpanData.newBuilder()
+            .setParentSpanId(PARENT_SPAN_ID)
+            .setSpanId(SPAN_ID)
+            .setTraceId(TRACE_ID)
+            .setName(SPAN_NAME)
+            .setKind(io.opentelemetry.trace.Span.Kind.SERVER)
+            .setTimedEvents(Collections.emptyList())
+            .setStatus(SPAN_DATA_STATUS)
+            .setStartEpochNanos(START_EPOCH_NANOS)
+            .setEndEpochNanos(END_EPOCH_NANOS)
+            .setTotalRecordedLinks(0)
+            .setHasRemoteParent(false)
+            .setHasEnded(true)
             .build();
-    private static final Span.TimeEvents TIME_EVENTS = Span.TimeEvents.newBuilder().build();
-    private static final io.opentelemetry.trace.Status SPAN_DATA_STATUS = io.opentelemetry.trace.Status.OK;
-    private static final Status SPAN_STATUS = Status.newBuilder().setCode(SPAN_DATA_STATUS.getCanonicalCode().value())
-            // .setMessage(SPAN_DATA_STATUS.getDescription())
+
+    spanDataList.add(spanDataOne);
+
+    // Some hardcoding of expected data for span.
+    List<Span> expectedSpans = new ArrayList<>();
+    Span spanOne = Span.newBuilder()
+            .setName("projects/" + PROJECT_ID + "/traces/" + TRACE_ID.toLowerBase16() + "/spans/" + SPAN_ID.toLowerBase16())
+            .setSpanId(SPAN_ID.toLowerBase16())
+            .setDisplayName(TruncatableString.newBuilder().setValue(SERVER_PREFIX + SPAN_NAME).setTruncatedByteCount(0).build())
+            .setStartTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(START_SECONDS).setNanos(START_NANOS).build())
+            .setAttributes(ATTRIBUTES)
+            .setTimeEvents(TIME_EVENTS)
+            .setStatus(SPAN_STATUS)
+            .setEndTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(END_SECONDS).setNanos(END_NANOS).build())
+            .setLinks(LINKS)
+            .setParentSpanId(PARENT_SPAN_ID.toLowerBase16())
+            .setSameProcessAsParentSpan(BoolValue.of(true))
             .build();
-    private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
+    // Instead of hardcoding as above, Span.parseFrom method can potentially be used to parse from a hardcoded proto
+    expectedSpans.add(spanOne);
 
+    // My original try, but batchWriteSpans is void and cannot be stubbed with a return value
+    // doReturn(expectedSpans).when(mockTraceServiceClient).batchWriteSpans(any(ProjectName.class), anyList());
 
-    // Some test cases, for example. Since the core function of this exporter is export(), we may focus on testing that.
+    // Instead of doReturn, doAnswer is better to deal with whenever batchWriteSpans() is called.
+    // Rather than actually call the BatchWriteSpans() method from the API, null is returned.
+    doAnswer(invocation -> null)
+            .when(mockTraceServiceClient).batchWriteSpans(eq(PROJECT_ID), anyList());
 
-    @Test
-    public void export(){
-        // Constructs an exporter instance.
-        exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
-        Collection<SpanData> spanDataList = new ArrayList<>();
+    // Invokes export();
+    assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
 
-        SpanData spanDataOne = SpanData.newBuilder()
-                .setParentSpanId(PARENT_SPAN_ID)
-                .setSpanId(SPAN_ID)
-                .setTraceId(TRACE_ID)
-                .setName(SPAN_NAME)
-                .setKind(io.opentelemetry.trace.Span.Kind.SERVER)
-                .setTimedEvents(Collections.emptyList())
-                .setStatus(SPAN_DATA_STATUS)
-                .setStartEpochNanos(START_EPOCH_NANOS)
-                .setEndEpochNanos(END_EPOCH_NANOS)
-                .setTotalRecordedLinks(0)
-                .setHasRemoteParent(false)
-                .setHasEnded(true)
-                .build();
+    // Make sure that the parameters passed to batchWriteSpans() are what we expect them to be
+    verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
+            eq(expectedSpans));
+  }
 
-        spanDataList.add(spanDataOne);
+  @org.junit.Test
+  public void export_EmptySpanDataList(){
+    // Constructs a exporter instance.
+    exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+    Collection<SpanData> spanDataList = new ArrayList<>();
 
-        // Some hardcoding of expected data for span.
-        List<Span> expectedSpans = new ArrayList<>();
-        Span spanOne = Span.newBuilder()
-                .setName("projects/" + PROJECT_ID + "/traces/" + TRACE_ID.toLowerBase16() + "/spans/" + SPAN_ID.toLowerBase16())
-                .setSpanId(SPAN_ID.toLowerBase16())
-                .setDisplayName(TruncatableString.newBuilder().setValue(SERVER_PREFIX + SPAN_NAME).setTruncatedByteCount(0).build())
-                .setStartTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(START_SECONDS).setNanos(START_NANOS).build())
-                .setAttributes(ATTRIBUTES)
-                .setTimeEvents(TIME_EVENTS)
-                .setStatus(SPAN_STATUS)
-                .setEndTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(END_SECONDS).setNanos(END_NANOS).build())
-                .setLinks(LINKS)
-                .setParentSpanId(PARENT_SPAN_ID.toLowerBase16())
-                .setSameProcessAsParentSpan(BoolValue.of(true))
-                .build();
-        // Instead of hardcoding as above, Span.parseFrom method can potentially be used to parse from a hardcoded proto
-        expectedSpans.add(spanOne);
+    // Invokes export();
+    assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
 
-        // My original try, but batchWriteSpans is void and cannot be stubbed with a return value
-        // doReturn(expectedSpans).when(mockTraceServiceClient).batchWriteSpans(any(ProjectName.class), anyList());
-
-        // Instead of doReturn, doAnswer is better to deal with whenever batchWriteSpans() is called.
-        // Rather than actually call the BatchWriteSpans() method from the API, null is returned.
-        doAnswer(invocation -> null)
-                .when(mockTraceServiceClient).batchWriteSpans(eq(PROJECT_ID), anyList());
-
-        // Invokes export();
-        assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
-
-        // Make sure that the parameters passed to batchWriteSpans() are what we expect them to be
-        verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
-                eq(expectedSpans));
-    }
-
-    @org.junit.Test
-    public void export_EmptySpanDataList(){
-        // Constructs a exporter instance.
-        exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
-        Collection<SpanData> spanDataList = new ArrayList<>();
-
-        // Invokes export();
-        assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
-
-        // Some verification.
-        List<Span> expectedSpans = new ArrayList<>();
-        verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
-                eq(expectedSpans));
-    }
+    // Some verification.
+    List<Span> expectedSpans = new ArrayList<>();
+    verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
+            eq(expectedSpans));
+  }
 
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -9,11 +9,8 @@ import com.google.protobuf.BoolValue;
 import com.google.rpc.Status;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.TraceId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,24 +29,12 @@ import static org.mockito.Mockito.eq;
 
 @RunWith(JUnit4.class)
 public class EndToEndTest {
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
-
-  @Mock
-  TraceServiceClient mockTraceServiceClient;
-
-  private TraceExporter exporter;
 
   private static final String PROJECT_ID = "project-id";
   private static final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>();
   private static final TraceId TRACE_ID = new TraceId(321, 123);
   private static final SpanId SPAN_ID = new SpanId(12345);
   private static final SpanId PARENT_SPAN_ID = new SpanId(54321);
-  private static final TraceFlags TRACE_FLAGS = TraceFlags.builder().build();
-  private static final TraceState TRACE_STATE = TraceState.builder().build();
-  private static final SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TRACE_FLAGS, TRACE_STATE);
   private static final String SPAN_NAME = "MySpanName";
   private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
   private static final long START_SECONDS = TimeUnit.NANOSECONDS.toSeconds(START_EPOCH_NANOS);
@@ -73,8 +58,17 @@ public class EndToEndTest {
           .build();
   private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
 
+  @Mock
+  TraceServiceClient mockTraceServiceClient;
+  private TraceExporter exporter;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
   @Test
-  public void export(){
+  public void exportMockSpanDataList(){
     exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
     Collection<SpanData> spanDataList = new ArrayList<>();
 
@@ -124,8 +118,8 @@ public class EndToEndTest {
             eq(expectedSpans));
   }
 
-  @org.junit.Test
-  public void export_EmptySpanDataList(){
+  @Test
+  public void exportEmptySpanDataList(){
     exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
     Collection<SpanData> spanDataList = new ArrayList<>();
 

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -140,7 +140,7 @@ public class EndToEndTest {
     Collection<SpanData> spanDataList = new ArrayList<>();
 
     // Invokes export();
-    assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
+    assertEquals(SpanExporter.ResultCode.SUCCESS, exporter.export(spanDataList));
 
     // Some verification.
     List<Span> expectedSpans = new ArrayList<>();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -44,7 +44,7 @@ public class EndToEndTest {
   private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
   private static final String SERVER_PREFIX = "Recv.";
   private static final String AGENT_LABEL_KEY = "g.co/agent";
-  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [0.3.0]";
+  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [0.6.0]";
   private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
           .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
   private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -1,0 +1,158 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.cloud.trace.v2.TraceServiceClient;
+import com.google.devtools.cloudtrace.v2.AttributeValue;
+import com.google.devtools.cloudtrace.v2.ProjectName;
+import com.google.devtools.cloudtrace.v2.Span;
+import com.google.devtools.cloudtrace.v2.TruncatableString;
+import com.google.protobuf.BoolValue;
+import com.google.rpc.Status;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.trace.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+//import com.google.testing.mockito.Mocks;
+
+
+@RunWith(JUnit4.class)
+public class EndToEndTest {
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+//    @Rule
+//    public final Mocks mocks = new Mocks(this);
+
+//creating a mock TraceServiceClient so that batchWriteSpans() method won't actually be called
+    TraceServiceClient mockTraceServiceClient = Mockito.mock(TraceServiceClient.class);
+
+    private TraceExporter exporter;
+
+    private static final String PROJECT_ID = "project-id";
+    private static final Map<String, AttributeValue> FIXED_ATTRIBUTES = new HashMap<>(); // Or fake some data if we want to test more.
+    private static final TraceId TRACE_ID = new TraceId(321, 123);
+    private static final SpanId SPAN_ID = new SpanId(12345);
+    private static final SpanId PARENT_SPAN_ID = new SpanId(54321);
+    //private static final SpanId PARENT_SPAN_ID = SpanId.fromLowerBase16("71da8d631536f5f1", 0);
+    private static final TraceFlags TRACE_FLAGS = TraceFlags.builder().build();
+    private static final TraceState TRACE_STATE = TraceState.builder().build();
+    private static final SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TRACE_FLAGS, TRACE_STATE);
+    private static final String SPAN_NAME = "MySpanName";
+    private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
+    private static final long START_SECONDS = TimeUnit.NANOSECONDS.toSeconds(START_EPOCH_NANOS);
+    private static final int START_NANOS = (int) (START_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(START_SECONDS));
+    private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
+    private static final long END_SECONDS = TimeUnit.NANOSECONDS.toSeconds(END_EPOCH_NANOS);
+    private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
+    private static final String SERVER_PREFIX = "Recv.";
+    private static final String AGENT_LABEL_KEY = "g.co/agent";
+    private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.3.0";
+    private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
+    private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
+                    .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
+    private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()
+            .setDroppedAttributesCount(0)
+            .putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE)
+            .build();
+    private static final Span.TimeEvents TIME_EVENTS = Span.TimeEvents.newBuilder().build();
+    private static final io.opentelemetry.trace.Status SPAN_DATA_STATUS = io.opentelemetry.trace.Status.OK;
+    private static final Status SPAN_STATUS = Status.newBuilder().setCode(SPAN_DATA_STATUS.getCanonicalCode().value())
+            //.setMessage(SPAN_DATA_STATUS.getDescription())
+            .build();
+    private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
+
+
+    // Some test cases, for example. Since the core function of this exporter is export(), we may focus on testing that.
+
+    @Test
+    public void export(){
+        // Constructs an exporter instance.
+        exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+        Collection<SpanData> spanDataList = new ArrayList<>();
+
+        //SpanData spanDataOne = SpanData.newBuilder().build();
+
+        SpanData spanDataOne = SpanData.newBuilder()
+                .setParentSpanId(PARENT_SPAN_ID)
+                .setSpanId(SPAN_ID)
+                .setTraceId(TRACE_ID)
+                .setName(SPAN_NAME)
+                .setKind(io.opentelemetry.trace.Span.Kind.SERVER)
+                .setTimedEvents(Collections.emptyList())
+                .setStatus(SPAN_DATA_STATUS)
+                .setStartEpochNanos(START_EPOCH_NANOS)
+                .setEndEpochNanos(END_EPOCH_NANOS)
+                .setTotalRecordedLinks(0)
+                .setHasRemoteParent(false)
+                .setHasEnded(true)
+                .build();
+
+        //spanDataList.add(spanDataOne);
+        spanDataList.add(spanDataOne);
+
+        // Some verification.
+        List<Span> expectedSpans = new ArrayList<>();
+        Span spanTwo = Span.newBuilder()
+                .setName("projects/" + PROJECT_ID + "/traces/" + TRACE_ID.toLowerBase16() + "/spans/" + SPAN_ID.toLowerBase16())
+                .setSpanId(SPAN_ID.toLowerBase16())
+                .setDisplayName(TruncatableString.newBuilder().setValue(SERVER_PREFIX + SPAN_NAME).setTruncatedByteCount(0).build())
+                .setStartTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(START_SECONDS).setNanos(START_NANOS).build())
+                .setAttributes(ATTRIBUTES)
+                .setTimeEvents(TIME_EVENTS)
+                .setStatus(SPAN_STATUS)
+                .setEndTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(END_SECONDS).setNanos(END_NANOS).build())
+                .setLinks(LINKS)
+                .setParentSpanId(PARENT_SPAN_ID.toLowerBase16())
+                .setSameProcessAsParentSpan(BoolValue.of(true))
+                .build();
+        //Span.parseFrom
+        expectedSpans.add(spanTwo);
+
+        //my original try, but batchWriteSpans is void and cannot be stubbed with a return value
+        //doReturn(expectedSpans).when(mockTraceServiceClient).batchWriteSpans(any(ProjectName.class), anyList());
+
+        //Instead of doReturn, doAnswer is better to deal with whenever batchWriteSpans() is called.
+        //Rather than actually call the BatchWriteSpans() method from the API, null is returned.
+        doAnswer(invocation -> {
+            //Object[] args = invocation.getArguments();
+            //Mock mock = (Mock) invocation.getMock();
+            return null;
+        })
+                .when(mockTraceServiceClient).batchWriteSpans(eq(PROJECT_ID), anyList());
+
+        // Invokes export();
+        assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
+
+        //make sure that the parameters passed to batchWriteSpans() are what we expect them to be
+        verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
+                eq(expectedSpans));
+    }
+
+    @org.junit.Test
+    public void export_EmptySpanDataList(){
+        // Constructs a exporter instance.
+        exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+        Collection<SpanData> spanDataList = new ArrayList<>();
+
+        // Invokes export();
+        assertEquals((SpanExporter.ResultCode.SUCCESS), (exporter.export(spanDataList)));
+
+        // Some verification.
+        List<Span> expectedSpans = new ArrayList<>();
+        verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
+                eq(expectedSpans));
+    }
+
+}

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -44,8 +44,7 @@ public class EndToEndTest {
   private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
   private static final String SERVER_PREFIX = "Recv.";
   private static final String AGENT_LABEL_KEY = "g.co/agent";
-  private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.3.0";
-  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
+  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [0.3.0]";
   private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
           .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
   private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()

--- a/exporters/trace/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/exporters/trace/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
# Context 

Add End to End Test ensuring that the spans generated by TraceTranslator's generateSpans() method and sent as a parameter to the batchWriteSpans() method are what we expect them to be.

# Tests
EndToEndTest.java is run with JUnit 4; can also run using `./gradlew test` on the command line
