### PR TITLE
Update OTEL version from 0.3.0 to current version 0.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
 
     ext {
         googleCloudVersion = '1.0.2'
-        openTelemetryVersion = '0.3.0'
+        openTelemetryVersion = '0.6.0'
         junitVersion = '4.13';
 
         libraries = [

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -6,6 +6,7 @@ import com.google.devtools.cloudtrace.v2.ProjectName;
 import com.google.devtools.cloudtrace.v2.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,6 +27,12 @@ public class TraceExporter implements SpanExporter {
     this.fixedAttributes = fixedAttributes;
   }
 
+  // TODO @imnoahcook add support for flush
+  @Override
+  public ResultCode flush() {
+    return ResultCode.FAILURE;
+  }
+
   @Override
   public ResultCode export(Collection<SpanData> spanDataList) {
     List<Span> spans = new ArrayList<>(spanDataList.size());
@@ -41,6 +48,4 @@ public class TraceExporter implements SpanExporter {
   public void shutdown() {
     throw new UnsupportedOperationException();
   }
-
-
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -1,7 +1,5 @@
 package com.google.cloud.opentelemetry.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
@@ -13,40 +11,56 @@ import com.google.devtools.cloudtrace.v2.SpanName;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.protobuf.BoolValue;
 import com.google.rpc.Status;
-
 import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.trace.Span.Kind;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 class TraceTranslator {
 
   // TODO(nilebox): Extract the constant
   private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.6.0";
   private static final String AGENT_LABEL_KEY = "g.co/agent";
-  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
-  private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
-          .setStringValue(toTruncatableStringProto(AGENT_LABEL_VALUE_STRING)).build();
+  private static final String AGENT_LABEL_VALUE_STRING =
+      "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
+  private static final AttributeValue AGENT_LABEL_VALUE =
+      AttributeValue.newBuilder()
+          .setStringValue(toTruncatableStringProto(AGENT_LABEL_VALUE_STRING))
+          .build();
   private static final String SERVER_PREFIX = "Recv.";
   private static final String CLIENT_PREFIX = "Sent.";
 
-  private static final ImmutableMap<String, String> HTTP_ATTRIBUTE_MAPPING = ImmutableMap.<String, String>builder()
-          .put("http.host", "/http/host").put("http.method", "/http/method").put("http.path", "/http/path")
-          .put("http.route", "/http/route").put("http.user_agent", "/http/user_agent")
-          .put("http.status_code", "/http/status_code").build();
+  private static final ImmutableMap<String, String> HTTP_ATTRIBUTE_MAPPING =
+      ImmutableMap.<String, String>builder()
+          .put("http.host", "/http/host")
+          .put("http.method", "/http/method")
+          .put("http.path", "/http/path")
+          .put("http.route", "/http/route")
+          .put("http.user_agent", "/http/user_agent")
+          .put("http.status_code", "/http/status_code")
+          .build();
 
   @VisibleForTesting
-  static Span generateSpan(SpanData spanData, String projectId, Map<String, AttributeValue> constAttributes) {
+  static Span generateSpan(
+      SpanData spanData, String projectId, Map<String, AttributeValue> constAttributes) {
     final String traceIdHex = spanData.getTraceId().toLowerBase16();
     final String spanIdHex = spanData.getSpanId().toLowerBase16();
-    SpanName spanName = SpanName.newBuilder().setProject(projectId).setTrace(traceIdHex).setSpan(spanIdHex).build();
-    Span.Builder spanBuilder = Span.newBuilder().setName(spanName.toString()).setSpanId(spanIdHex)
-            .setDisplayName(toTruncatableStringProto(toDisplayName(spanData.getName(), spanData.getKind())))
+    SpanName spanName =
+        SpanName.newBuilder().setProject(projectId).setTrace(traceIdHex).setSpan(spanIdHex).build();
+    Span.Builder spanBuilder =
+        Span.newBuilder()
+            .setName(spanName.toString())
+            .setSpanId(spanIdHex)
+            .setDisplayName(
+                toTruncatableStringProto(toDisplayName(spanData.getName(), spanData.getKind())))
             .setStartTime(toTimestampProto(spanData.getStartEpochNanos()))
             .setAttributes(toAttributesProto(spanData.getAttributes(), constAttributes))
             .setTimeEvents(toTimeEventsProto(spanData.getEvents()));
@@ -91,13 +105,11 @@ class TraceTranslator {
 
     return com.google.protobuf.Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
   }
-
-  // events -> getEvents
-  // attribute map -> readableAttributes
+  
   // These are the attributes of the Span, where usually we may add more
   // attributes like the agent.
-  private static Attributes toAttributesProto(ReadableAttributes attributes,
-                                              Map<String, AttributeValue> fixedAttributes) {
+  private static Attributes toAttributesProto(
+      ReadableAttributes attributes, Map<String, AttributeValue> fixedAttributes) {
     Attributes.Builder attributesBuilder = toAttributesBuilderProto(attributes);
     attributesBuilder.putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE);
     for (Map.Entry<String, AttributeValue> entry : fixedAttributes.entrySet()) {
@@ -112,17 +124,19 @@ class TraceTranslator {
 
   private static Attributes.Builder toAttributesBuilderProto(ReadableAttributes attributes) {
     Attributes.Builder attributesBuilder =
-            // TODO (nilebox): Does OpenTelemetry support droppedAttributesCount?
-            Attributes.newBuilder().setDroppedAttributesCount(0);
-    attributes.forEach((key, value) -> {
-      AttributeValue attributeValue = toAttributeValueProto(value);
-      attributesBuilder.putAttributeMap(mapKey(key), attributeValue);
-    });
+        // TODO (nilebox): Does OpenTelemetry support droppedAttributesCount?
+        Attributes.newBuilder().setDroppedAttributesCount(0);
+    attributes.forEach(
+        (key, value) -> {
+          AttributeValue attributeValue = toAttributeValueProto(value);
+          attributesBuilder.putAttributeMap(mapKey(key), attributeValue);
+        });
 
     return attributesBuilder;
   }
 
-  private static AttributeValue toAttributeValueProto(io.opentelemetry.common.AttributeValue attributeValue) {
+  private static AttributeValue toAttributeValueProto(
+      io.opentelemetry.common.AttributeValue attributeValue) {
     AttributeValue.Builder builder = AttributeValue.newBuilder();
     switch (attributeValue.getType()) {
       case STRING:
@@ -135,7 +149,8 @@ class TraceTranslator {
         builder.setIntValue(attributeValue.getLongValue());
         break;
       case DOUBLE:
-        builder.setStringValue(toTruncatableStringProto(String.valueOf(attributeValue.getDoubleValue())));
+        builder.setStringValue(
+            toTruncatableStringProto(String.valueOf(attributeValue.getDoubleValue())));
         break;
     }
     return builder.build();
@@ -153,10 +168,13 @@ class TraceTranslator {
     Span.TimeEvents.Builder timeEventsBuilder = Span.TimeEvents.newBuilder();
 
     for (Event event : events) {
-      timeEventsBuilder
-              .addTimeEvent(Span.TimeEvent.newBuilder().setTime(toTimestampProto(event.getEpochNanos())).setAnnotation(
-                      Span.TimeEvent.Annotation.newBuilder().setDescription(toTruncatableStringProto(event.getName()))
-                              .setAttributes(toAttributesProto(event.getAttributes()))));
+      timeEventsBuilder.addTimeEvent(
+          Span.TimeEvent.newBuilder()
+              .setTime(toTimestampProto(event.getEpochNanos()))
+              .setAnnotation(
+                  Span.TimeEvent.Annotation.newBuilder()
+                      .setDescription(toTruncatableStringProto(event.getName()))
+                      .setAttributes(toAttributesProto(event.getAttributes()))));
     }
 
     return timeEventsBuilder.build();
@@ -170,9 +188,10 @@ class TraceTranslator {
     return statusBuilder.build();
   }
 
-  private static Links toLinksProto(List<io.opentelemetry.sdk.trace.data.SpanData.Link> links, int totalRecordedLinks) {
-    final Links.Builder linksBuilder = Links.newBuilder()
-            .setDroppedLinksCount(Math.max(0, totalRecordedLinks - links.size()));
+  private static Links toLinksProto(
+      List<io.opentelemetry.sdk.trace.data.SpanData.Link> links, int totalRecordedLinks) {
+    final Links.Builder linksBuilder =
+        Links.newBuilder().setDroppedLinksCount(Math.max(0, totalRecordedLinks - links.size()));
     for (io.opentelemetry.sdk.trace.data.SpanData.Link link : links) {
       linksBuilder.addLink(toLinkProto(link));
     }
@@ -181,9 +200,12 @@ class TraceTranslator {
 
   private static Link toLinkProto(io.opentelemetry.sdk.trace.data.SpanData.Link link) {
     checkNotNull(link);
-    return Link.newBuilder().setTraceId(link.getContext().getTraceId().toLowerBase16())
-            .setSpanId(link.getContext().getSpanId().toLowerBase16()).setType(Link.Type.TYPE_UNSPECIFIED)
-            .setAttributes(toAttributesBuilderProto(link.getAttributes())).build();
+    return Link.newBuilder()
+        .setTraceId(link.getContext().getTraceId().toLowerBase16())
+        .setSpanId(link.getContext().getSpanId().toLowerBase16())
+        .setType(Link.Type.TYPE_UNSPECIFIED)
+        .setAttributes(toAttributesBuilderProto(link.getAttributes()))
+        .build();
   }
 
   @VisibleForTesting
@@ -198,8 +220,8 @@ class TraceTranslator {
     return Collections.unmodifiableMap(resourceLabels);
   }
 
-  private static void putToResourceAttributeMap(Map<String, AttributeValue> map, String attributeName,
-                                                String attributeValue) {
+  private static void putToResourceAttributeMap(
+      Map<String, AttributeValue> map, String attributeName, String attributeValue) {
     map.put(createResourceLabelKey(attributeName), toStringAttributeValueProto(attributeValue));
   }
 
@@ -213,6 +235,5 @@ class TraceTranslator {
     return AttributeValue.newBuilder().setStringValue(toTruncatableStringProto(value)).build();
   }
 
-  private TraceTranslator() {
-  }
+  private TraceTranslator() {}
 }


### PR DESCRIPTION
# Context
I was working on writing and example class and was unable to use `OpenTelemetry.getTracer` I assumed that it was because we are using an earlier version of OpenTelemetry, so I decided to update it.

# Solution.
Update OpenTelemetry version to 0.6.0 in `build.gradle`, and then reflect the changes in `TraceExporter` and `TraceTranslator`.

The biggest changes were the types of `Attributes` being changed to `ReadableAttributes`, which seems to be an interface for a map, and `TimedEvents` being changed to an `Event`

Additionally, I ran the google java formatter on the file... which makes it much less readable. Is there an alternative formatter that we use?

# Test plan
```sh
$ gradle build && gradle test

BUILD SUCCESSFUL in 1s
4 actionable tasks: 4 up-to-date

BUILD SUCCESSFUL in 803ms
3 actionable tasks: 3 up-to-date
```

# Open Questions
I assumed that many of the changes made were pretty direct comparisons, and I discovered how other people changed them looking at git blame. I'm not 100% sure these changes are accurate however, so if anybody has more context on these changes that would be useful.