### PR TITLE
Add unit tests for TraceTranslator class

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -83,7 +83,8 @@ class TraceTranslator {
     return spanBuilder.build();
   }
 
-  private static String toDisplayName(String spanName, @javax.annotation.Nullable Kind spanKind) {
+  @VisibleForTesting
+  static String toDisplayName(String spanName, @javax.annotation.Nullable Kind spanKind) {
     if (spanKind == Kind.SERVER && !spanName.startsWith(SERVER_PREFIX)) {
       return SERVER_PREFIX + spanName;
     }
@@ -95,11 +96,13 @@ class TraceTranslator {
     return spanName;
   }
 
-  private static TruncatableString toTruncatableStringProto(String string) {
+  @VisibleForTesting
+  static TruncatableString toTruncatableStringProto(String string) {
     return TruncatableString.newBuilder().setValue(string).setTruncatedByteCount(0).build();
   }
 
-  private static com.google.protobuf.Timestamp toTimestampProto(long epochNanos) {
+  @VisibleForTesting
+  static com.google.protobuf.Timestamp toTimestampProto(long epochNanos) {
     long seconds = TimeUnit.NANOSECONDS.toSeconds(epochNanos);
     int nanos = (int) (epochNanos - TimeUnit.SECONDS.toNanos(seconds));
 
@@ -108,7 +111,8 @@ class TraceTranslator {
   
   // These are the attributes of the Span, where usually we may add more
   // attributes like the agent.
-  private static Attributes toAttributesProto(
+  @VisibleForTesting
+  static Attributes toAttributesProto(
       ReadableAttributes attributes, Map<String, AttributeValue> fixedAttributes) {
     Attributes.Builder attributesBuilder = toAttributesBuilderProto(attributes);
     attributesBuilder.putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE);
@@ -164,7 +168,8 @@ class TraceTranslator {
     }
   }
 
-  private static Span.TimeEvents toTimeEventsProto(List<Event> events) {
+  @VisibleForTesting
+  static Span.TimeEvents toTimeEventsProto(List<Event> events) {
     Span.TimeEvents.Builder timeEventsBuilder = Span.TimeEvents.newBuilder();
 
     for (Event event : events) {
@@ -180,7 +185,8 @@ class TraceTranslator {
     return timeEventsBuilder.build();
   }
 
-  private static Status toStatusProto(io.opentelemetry.trace.Status status) {
+  @VisibleForTesting
+  static Status toStatusProto(io.opentelemetry.trace.Status status) {
     Status.Builder statusBuilder = Status.newBuilder().setCode(status.getCanonicalCode().value());
     if (status.getDescription() != null) {
       statusBuilder.setMessage(status.getDescription());
@@ -188,7 +194,8 @@ class TraceTranslator {
     return statusBuilder.build();
   }
 
-  private static Links toLinksProto(
+  @VisibleForTesting
+  static Links toLinksProto(
       List<io.opentelemetry.sdk.trace.data.SpanData.Link> links, int totalRecordedLinks) {
     final Links.Builder linksBuilder =
         Links.newBuilder().setDroppedLinksCount(Math.max(0, totalRecordedLinks - links.size()));

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -1,0 +1,198 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.devtools.cloudtrace.v2.AttributeValue;
+import com.google.devtools.cloudtrace.v2.Span;
+import com.google.devtools.cloudtrace.v2.TruncatableString;
+import com.google.rpc.Status;
+import io.opentelemetry.common.Attributes;
+import io.opentelemetry.common.ReadableAttributes;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class TraceTranslatorTest {
+
+  @Test
+  public void toDisplayNameTest(){
+    String serverPrefixSpanName = "Recv. mySpanName";
+    String clientPrefixSpanName = "Sent. mySpanName";
+    String regularSpanName = "regularSpanName";
+    Kind serverSpanKind = Kind.SERVER;
+    Kind clientSpanKind = Kind.CLIENT;
+
+    assertEquals("Recv. mySpanName", TraceTranslator.toDisplayName(serverPrefixSpanName, serverSpanKind));
+    assertEquals("Sent. mySpanName", TraceTranslator.toDisplayName(clientPrefixSpanName, clientSpanKind));
+    assertEquals("Recv.regularSpanName", TraceTranslator.toDisplayName(regularSpanName, serverSpanKind));
+    assertEquals("Sent.regularSpanName", TraceTranslator.toDisplayName(regularSpanName, clientSpanKind));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullTruncatableStringProtoTest(){
+    TruncatableString nullTruncatable = TraceTranslator.toTruncatableStringProto(null);
+
+    assertNull(nullTruncatable.getValue());
+    assertEquals(0, nullTruncatable.getTruncatedByteCount());
+  }
+
+  @Test
+  public void toTruncatableStringProtoTest(){
+    String truncatableString = "myTruncatableString";
+    TruncatableString testTruncatable = TraceTranslator.toTruncatableStringProto(truncatableString);
+
+    assertEquals("myTruncatableString", testTruncatable.getValue());
+    assertEquals(0, testTruncatable.getTruncatedByteCount());
+  }
+
+  @Test
+  public void toTimestampProtoTest(){
+    long epochNanos = TimeUnit.SECONDS.toNanos(3001) + 255;
+    com.google.protobuf.Timestamp timestamp = TraceTranslator.toTimestampProto(epochNanos);
+
+    assertEquals(3001, timestamp.getSeconds());
+    assertEquals(255, timestamp.getNanos());
+  }
+
+  @Test
+  public void toAttributesProtoTest(){
+    ReadableAttributes attributes = Attributes.newBuilder()
+            .setAttribute("myKey", "myValue")
+            .setAttribute("http.status_code", true)
+            .setAttribute("anotherKey", 100)
+            .setAttribute("http.host", 3.14)
+            .build();
+    Map<String, AttributeValue> fixedAttributes = new LinkedHashMap<>();
+    fixedAttributes.put("fixed", AttributeValue.newBuilder().setStringValue
+        (TruncatableString.newBuilder().setValue("attributes").setTruncatedByteCount(0).build()).build());
+    fixedAttributes.put("another", AttributeValue.newBuilder().setStringValue
+        (TruncatableString.newBuilder().setValue("entry").setTruncatedByteCount(0).build()).build());
+
+    Span.Attributes.Builder attributesBuilder = Span.Attributes.newBuilder().setDroppedAttributesCount(0)
+        .putAttributeMap("myKey", AttributeValue.newBuilder().setStringValue
+            (TruncatableString.newBuilder().setValue("myValue").setTruncatedByteCount(0)).build())
+        .putAttributeMap("/http/host", AttributeValue.newBuilder().setStringValue
+            (TruncatableString.newBuilder().setValue(String.valueOf(3.14)).setTruncatedByteCount(0)).build())
+        .putAttributeMap("/http/status_code", AttributeValue.newBuilder().setBoolValue
+            (true).build())
+        .putAttributeMap("anotherKey", AttributeValue.newBuilder().setIntValue
+            (100).build())
+        .putAttributeMap("g.co/agent", AttributeValue.newBuilder().setStringValue
+            (TruncatableString.newBuilder().setValue("opentelemetry-java [0.6.0]").setTruncatedByteCount(0)).build());
+    for (Map.Entry<String, AttributeValue> entry : fixedAttributes.entrySet()) {
+      attributesBuilder.putAttributeMap(entry.getKey(), entry.getValue());
+    }
+
+    Span.Attributes allAtributes = attributesBuilder.build();
+
+    assertEquals(allAtributes, TraceTranslator.toAttributesProto(attributes, fixedAttributes));
+
+  }
+
+  @Test
+  public void toTimeEventsProtoTest(){
+    List<SpanData.Event> events = new ArrayList<>();
+    SpanData.Event eventOne = new SpanData.Event() {
+      //The SpanData.Event interfaces requires us to override these four methods
+      @Override
+      public long getEpochNanos() {
+        return 0;
+      }
+
+      @Override
+      public int getTotalAttributeCount() {
+        return 0;
+      }
+
+      @Override
+      public String getName() {
+        return "eventOne";
+      }
+
+      @Override
+      public Attributes getAttributes() {
+        return Attributes.newBuilder().setAttribute("key", "value").build();
+      }
+    };
+    events.add(eventOne);
+
+    Span.TimeEvents timeEvents = TraceTranslator.toTimeEventsProto(events);
+    assertEquals(1, timeEvents.getTimeEventCount());
+    //TODO: Figure out how to use timeEvents to call SpanData.Event methods to ensure those are working properly
+  }
+
+  @Test
+  public void toStatusProtoTest(){
+    io.opentelemetry.trace.Status myStatus = io.opentelemetry.trace.Status.OK.withDescription("Status description");
+    Status spanStatus = TraceTranslator.toStatusProto(myStatus);
+
+    //The int representation is 0 for canonical code "OK".
+    assertEquals(0, spanStatus.getCode());
+    assertEquals("Status description", spanStatus.getMessage());
+  }
+  
+  @Test
+  public void toLinksProtoTest(){
+    List<io.opentelemetry.sdk.trace.data.SpanData.Link> links = new ArrayList<>();
+
+    TraceId traceIdOne = new TraceId(321, 123);
+    SpanId spanIdOne = new SpanId(12345);
+    TraceFlags traceFlagsOne = TraceFlags.builder().build();
+    TraceState traceStateOne = TraceState.builder().build();
+    SpanContext spanContextOne = SpanContext.create(traceIdOne, spanIdOne, traceFlagsOne, traceStateOne);
+    Attributes attributesOne = Attributes.newBuilder().setAttribute("key", "value").build();
+    io.opentelemetry.sdk.trace.data.SpanData.Link linkOne =  io.opentelemetry.sdk.trace.data.SpanData.Link.create(spanContextOne, attributesOne);
+
+    TraceId traceIdTwo = new TraceId(32473, 24893);
+    SpanId spanIdTwo = new SpanId(54321);
+    TraceFlags traceFlagsTwo = TraceFlags.builder().build();
+    TraceState traceStateTwo = TraceState.builder().build();
+    SpanContext spanContextTwo = SpanContext.create(traceIdTwo, spanIdTwo, traceFlagsTwo, traceStateTwo);
+    Attributes attributesTwo = Attributes.newBuilder().setAttribute("random string", "another random string").build();
+    io.opentelemetry.sdk.trace.data.SpanData.Link linkTwo =  io.opentelemetry.sdk.trace.data.SpanData.Link.create(spanContextTwo, attributesTwo);
+
+    links.add(linkOne);
+    links.add(linkTwo);
+    Span.Links finalLinks = TraceTranslator.toLinksProto(links, 2);
+
+    assertEquals(2, finalLinks.getLinkCount());
+    assertEquals(0, finalLinks.getDroppedLinksCount());
+
+    assertEquals(traceIdOne.toLowerBase16(), finalLinks.getLink(0).getTraceId());
+    assertEquals(spanIdOne.toLowerBase16(), finalLinks.getLink(0).getSpanId());
+    //the int representation is 0 for (Link.Type.TYPE_UNSPECIFIED), which is given in TraceTranslator.
+    assertEquals(0, finalLinks.getLink(0).getTypeValue());
+    assertTrue(finalLinks.getLink(0).getAttributes().containsAttributeMap("key"));
+
+    assertEquals(traceIdTwo.toLowerBase16(), finalLinks.getLink(1).getTraceId());
+    assertEquals(spanIdTwo.toLowerBase16(), finalLinks.getLink(1).getSpanId());
+    assertEquals(0, finalLinks.getLink(1).getTypeValue());
+    assertTrue(finalLinks.getLink(1).getAttributes().containsAttributeMap("random string"));
+    assertFalse(finalLinks.getLink(1).getAttributes().containsAttributeMap("key"));
+  }
+
+  @Test
+  public void getResourceLabelsTest(){
+    Map<String, String> nullResources = new HashMap<>();
+    Map<String, String> resources = new HashMap<>();
+    resources.put("testOne", "testTwo");
+    resources.put("another", "entry");
+
+    Map<String, AttributeValue> resourceLabels = new LinkedHashMap<>();
+    resourceLabels.put("g.co/r/testOne", AttributeValue.newBuilder().setStringValue
+            (TruncatableString.newBuilder().setValue("testTwo").setTruncatedByteCount(0).build()).build());
+    resourceLabels.put("g.co/r/another", AttributeValue.newBuilder().setStringValue
+            (TruncatableString.newBuilder().setValue("entry").setTruncatedByteCount(0).build()).build());
+
+    assertEquals(Collections.emptyMap(), TraceTranslator.getResourceLabels(nullResources));
+    assertEquals(Collections.unmodifiableMap(resourceLabels), TraceTranslator.getResourceLabels(resources));
+  }
+
+}

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -8,15 +8,21 @@ import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.*;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import io.opentelemetry.trace.SpanContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(JUnit4.class)
 public class TraceTranslatorTest {
@@ -100,7 +106,7 @@ public class TraceTranslatorTest {
   public void toTimeEventsProtoTest(){
     List<SpanData.Event> events = new ArrayList<>();
     SpanData.Event eventOne = new SpanData.Event() {
-      //The SpanData.Event interfaces requires us to override these four methods
+      // The SpanData.Event interfaces requires us to override these four methods
       @Override
       public long getEpochNanos() {
         return 0;
@@ -133,8 +139,9 @@ public class TraceTranslatorTest {
     io.opentelemetry.trace.Status myStatus = io.opentelemetry.trace.Status.OK.withDescription("Status description");
     Status spanStatus = TraceTranslator.toStatusProto(myStatus);
 
-    //The int representation is 0 for canonical code "OK".
-    assertEquals(0, spanStatus.getCode());
+    // The int representation is 0 for canonical code "OK".
+    assertEquals(0,myStatus.getCanonicalCode().value());
+    assertEquals(io.opentelemetry.trace.Status.CanonicalCode.OK, myStatus.getCanonicalCode());
     assertEquals("Status description", spanStatus.getMessage());
   }
   
@@ -167,7 +174,7 @@ public class TraceTranslatorTest {
 
     assertEquals(traceIdOne.toLowerBase16(), finalLinks.getLink(0).getTraceId());
     assertEquals(spanIdOne.toLowerBase16(), finalLinks.getLink(0).getSpanId());
-    //the int representation is 0 for (Link.Type.TYPE_UNSPECIFIED), which is given in TraceTranslator.
+    // The int representation is 0 for (Link.Type.TYPE_UNSPECIFIED), which is given in TraceTranslator.
     assertEquals(0, finalLinks.getLink(0).getTypeValue());
     assertTrue(finalLinks.getLink(0).getAttributes().containsAttributeMap("key"));
 


### PR DESCRIPTION
# Context

Create unit tests to test all methods in TraceTranslator (except for generateSpans, as generateSpans is more or less just a combination of all the other methods anyways).

# Test

TraceTranslatorTest.java is run with JUnit 4; can also run using ./gradlew test on the command line