### PR TITLE
Switch EndToEndTest to use mock server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
         maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
@@ -17,7 +16,6 @@ subprojects {
     ext {
         autoValueVersion = '1.7.4'
         googleCloudVersion = '1.0.2'
-        mockitoVersion = '2.+'
         openTelemetryVersion = '0.6.0'
         junitVersion = '4.13';
 
@@ -32,8 +30,6 @@ subprojects {
         ]
         testLibraries = [
                 junit:"junit:junit:${junitVersion}",
-                mockito:"org.mockito:mockito-core:${mockitoVersion}",
-
         ]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ subprojects {
                 auto_value_annotations: "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
                 auto_value: "com.google.auto.value:auto-value:${autoValueVersion}",
                 google_cloud_core: "com.google.cloud:google-cloud-core:${googleCloudVersion}",
+                google_cloud_grpc: "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleCloudVersion}",
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
                 opentelemetry_api:"io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
                 opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -9,5 +9,4 @@ dependencies {
     api(libraries.google_cloud_trace)
     api(libraries.google_cloud_grpc)
     testImplementation(testLibraries.junit)
-    testCompile(testLibraries.mockito)
 }

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api(libraries.opentelemetry_sdk)
     api(libraries.google_cloud_core)
     api(libraries.google_cloud_trace)
+    api(libraries.google_cloud_grpc)
     testImplementation(testLibraries.junit)
     testCompile(testLibraries.mockito)
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
@@ -1,0 +1,10 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.devtools.cloudtrace.v2.ProjectName;
+import com.google.devtools.cloudtrace.v2.Span;
+
+import java.util.List;
+
+public interface CloudTraceClient {
+    void batchWriteSpans(ProjectName name, List<Span> spans);
+}

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
@@ -1,0 +1,19 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.cloud.trace.v2.TraceServiceClient;
+import com.google.devtools.cloudtrace.v2.ProjectName;
+import com.google.devtools.cloudtrace.v2.Span;
+
+import java.util.List;
+
+public class CloudTraceClientImpl implements CloudTraceClient {
+    private final TraceServiceClient traceServiceClient;
+
+    public CloudTraceClientImpl(TraceServiceClient traceServiceClient) {
+        this.traceServiceClient = traceServiceClient;
+    }
+
+    public final void batchWriteSpans(ProjectName name, List<Span> spans) {
+        traceServiceClient.batchWriteSpans(name, spans);
+    }
+}

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
@@ -10,15 +10,15 @@ import io.grpc.ManagedChannelBuilder;
 import java.util.List;
 
 // A simplified version of TraceServiceClient, used ONLY for testing purposes.
-public class MockTraceServiceClient {
+public class MockCloudTraceClient implements CloudTraceClient{
 
     TraceServiceGrpc.TraceServiceBlockingStub blockingStub;
 
-    public MockTraceServiceClient(String host, int port) {
+    public MockCloudTraceClient(String host, int port) {
         this(ManagedChannelBuilder.forAddress(host, port).usePlaintext());
     }
 
-    public MockTraceServiceClient(ManagedChannelBuilder<?> channelBuilder) {
+    public MockCloudTraceClient(ManagedChannelBuilder<?> channelBuilder) {
         Channel channel = channelBuilder.build();
         blockingStub = TraceServiceGrpc.newBlockingStub(channel);
     }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockTraceServiceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockTraceServiceClient.java
@@ -9,6 +9,7 @@ import io.grpc.ManagedChannelBuilder;
 
 import java.util.List;
 
+// A simplified version of TraceServiceClient, used ONLY for testing purposes.
 public class MockTraceServiceClient {
 
     TraceServiceGrpc.TraceServiceBlockingStub blockingStub;

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockTraceServiceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockTraceServiceClient.java
@@ -1,0 +1,33 @@
+package com.google.cloud.opentelemetry.trace;
+
+import com.google.devtools.cloudtrace.v2.BatchWriteSpansRequest;
+import com.google.devtools.cloudtrace.v2.ProjectName;
+import com.google.devtools.cloudtrace.v2.Span;
+import com.google.devtools.cloudtrace.v2.TraceServiceGrpc;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.util.List;
+
+public class MockTraceServiceClient {
+
+    TraceServiceGrpc.TraceServiceBlockingStub blockingStub;
+
+    public MockTraceServiceClient(String host, int port) {
+        this(ManagedChannelBuilder.forAddress(host, port).usePlaintext());
+    }
+
+    public MockTraceServiceClient(ManagedChannelBuilder<?> channelBuilder) {
+        Channel channel = channelBuilder.build();
+        blockingStub = TraceServiceGrpc.newBlockingStub(channel);
+    }
+
+    public final void batchWriteSpans(ProjectName name, List<Span> spans) {
+        BatchWriteSpansRequest request =
+                BatchWriteSpansRequest.newBuilder()
+                        .setName(name.toString())
+                        .addAllSpans(spans)
+                        .build();
+        blockingStub.batchWriteSpans(request);
+    }
+}

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -23,8 +23,7 @@ import static com.google.api.client.util.Preconditions.checkNotNull;
 
 public class TraceExporter implements SpanExporter {
 
-  private final TraceServiceClient traceServiceClient;
-  private final MockTraceServiceClient mockTraceServiceClient;
+  private final CloudTraceClient cloudTraceClient;
   private final ProjectName projectName;
   private final String projectId;
   private final Map<String, AttributeValue> fixedAttributes;
@@ -44,14 +43,14 @@ public class TraceExporter implements SpanExporter {
           projectId, credentials, configuration.getFixedAttributes(), configuration.getDeadline());
     }
     return TraceExporter.createWithClient(
-        projectId, TraceServiceClient.create(stub), configuration.getFixedAttributes());
+        projectId, new CloudTraceClientImpl(TraceServiceClient.create(stub)), configuration.getFixedAttributes());
   }
 
   private static TraceExporter createWithClient(
       String projectId,
-      TraceServiceClient traceServiceClient,
+      CloudTraceClient cloudTraceClient,
       Map<String, AttributeValue> fixedAttributes) {
-    return new TraceExporter(projectId, traceServiceClient, fixedAttributes);
+    return new TraceExporter(projectId, cloudTraceClient, fixedAttributes);
   }
 
   private static TraceExporter createWithCredentials(
@@ -69,28 +68,15 @@ public class TraceExporter implements SpanExporter {
         .batchWriteSpansSettings()
         .setSimpleTimeoutNoRetries(org.threeten.bp.Duration.ofMillis(deadline.toMillis()));
     return new TraceExporter(
-        projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
-  }
-
-  // Constructor used ONLY for testing. Uses a MockTraceServiceClient.
-  TraceExporter(
-          String projectId,
-          MockTraceServiceClient mockTraceServiceClient,
-          Map<String, AttributeValue> fixedAttributes) {
-    this.projectId = projectId;
-    this.traceServiceClient = null;
-    this.mockTraceServiceClient = mockTraceServiceClient;
-    this.projectName = ProjectName.of(projectId);
-    this.fixedAttributes = fixedAttributes;
+        projectId, new CloudTraceClientImpl(TraceServiceClient.create(builder.build())), fixedAttributes);
   }
 
   TraceExporter(
       String projectId,
-      TraceServiceClient traceServiceClient,
+      CloudTraceClient cloudTraceClient,
       Map<String, AttributeValue> fixedAttributes) {
     this.projectId = projectId;
-    this.traceServiceClient = traceServiceClient;
-    this.mockTraceServiceClient = null;
+    this.cloudTraceClient = cloudTraceClient;
     this.projectName = ProjectName.of(projectId);
     this.fixedAttributes = fixedAttributes;
   }
@@ -108,11 +94,7 @@ public class TraceExporter implements SpanExporter {
       spans.add(TraceTranslator.generateSpan(spanData, projectId, fixedAttributes));
     }
 
-    if (mockTraceServiceClient != null) {
-      mockTraceServiceClient.batchWriteSpans(projectName, spans);
-    } else {
-      traceServiceClient.batchWriteSpans(projectName, spans);
-    }
+    cloudTraceClient.batchWriteSpans(projectName, spans);
     return ResultCode.SUCCESS;
   }
 

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -72,7 +72,7 @@ public class TraceExporter implements SpanExporter {
         projectId, TraceServiceClient.create(builder.build()), fixedAttributes);
   }
 
-  // Constructor used ONLY for testing. Uses a mock trace service client.
+  // Constructor used ONLY for testing. Uses a MockTraceServiceClient.
   TraceExporter(
           String projectId,
           MockTraceServiceClient mockTraceServiceClient,

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -28,9 +28,11 @@ class TraceTranslator {
 
   // TODO(nilebox): Extract the constant
   private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.6.0";
+  private static final String EXPORTER_VERSION = "0.1.0";
   private static final String AGENT_LABEL_KEY = "g.co/agent";
   private static final String AGENT_LABEL_VALUE_STRING =
-      "opentelemetry-java [" + OPEN_TELEMETRY_LIBRARY_VERSION + "]";
+      "opentelemetry-java " + OPEN_TELEMETRY_LIBRARY_VERSION +
+              "; google-cloud-trace-exporter " + EXPORTER_VERSION;
   private static final AttributeValue AGENT_LABEL_VALUE =
       AttributeValue.newBuilder()
           .setStringValue(toTruncatableStringProto(AGENT_LABEL_VALUE_STRING))

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -40,7 +40,7 @@ public class EndToEndTest {
   private static final Status SPAN_DATA_STATUS = Status.OK;
   private static final String LOCALHOST = "127.0.0.1";
 
-  private MockTraceServiceClient mockTraceServiceClient;
+  private MockCloudTraceClient mockCloudTraceClient;
   private TraceExporter exporter;
   private Process mockServerProcess;
 
@@ -61,7 +61,7 @@ public class EndToEndTest {
     mockServerProcess = pb.start();
 
     // Setup the mock trace client.
-    mockTraceServiceClient = new MockTraceServiceClient(LOCALHOST, port);
+    mockCloudTraceClient = new MockCloudTraceClient(LOCALHOST, port);
 
     // Block until the mock server starts (it will output the address after starting).
     BufferedReader br = new BufferedReader(new InputStreamReader(mockServerProcess.getInputStream()));
@@ -75,7 +75,7 @@ public class EndToEndTest {
 
   @Test
   public void exportMockSpanDataList(){
-    exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+    exporter = new TraceExporter(PROJECT_ID, mockCloudTraceClient, FIXED_ATTRIBUTES);
     Collection<SpanData> spanDataList = new ArrayList<>();
 
     TestSpanData spanDataOne = TestSpanData.newBuilder()
@@ -101,7 +101,7 @@ public class EndToEndTest {
 
   @Test
   public void exportEmptySpanDataList(){
-    exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
+    exporter = new TraceExporter(PROJECT_ID, mockCloudTraceClient, FIXED_ATTRIBUTES);
     Collection<SpanData> spanDataList = new ArrayList<>();
 
     // Invokes export();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -55,7 +55,7 @@ public class EndToEndTest {
 
     // Start the mock server. This assumes the binary is present and in $PATH.
     // Typically, the CI will be the one that curls the binary and adds it to $PATH.
-    String[] cmdArray = new String[]{"mock_server-x64-linux", "-address", address};
+    String[] cmdArray = new String[]{"mock_server-x64-linux-v0-alpha", "-address", address};
     ProcessBuilder pb = new ProcessBuilder(cmdArray);
     pb.redirectErrorStream(true);
     mockServerProcess = pb.start();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -1,31 +1,30 @@
 package com.google.cloud.opentelemetry.trace;
 
-import com.google.cloud.trace.v2.TraceServiceClient;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
-import com.google.devtools.cloudtrace.v2.ProjectName;
-import com.google.devtools.cloudtrace.v2.Span;
-import com.google.devtools.cloudtrace.v2.TruncatableString;
-import com.google.protobuf.BoolValue;
-import com.google.rpc.Status;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceId;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import java.util.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.eq;
 
 @RunWith(JUnit4.class)
 public class EndToEndTest {
@@ -37,33 +36,41 @@ public class EndToEndTest {
   private static final SpanId PARENT_SPAN_ID = new SpanId(54321);
   private static final String SPAN_NAME = "MySpanName";
   private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
-  private static final long START_SECONDS = TimeUnit.NANOSECONDS.toSeconds(START_EPOCH_NANOS);
-  private static final int START_NANOS = (int) (START_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(START_SECONDS));
   private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
-  private static final long END_SECONDS = TimeUnit.NANOSECONDS.toSeconds(END_EPOCH_NANOS);
-  private static final int END_NANOS = (int) (END_EPOCH_NANOS - TimeUnit.SECONDS.toNanos(END_SECONDS));
-  private static final String SERVER_PREFIX = "Recv.";
-  private static final String AGENT_LABEL_KEY = "g.co/agent";
-  private static final String AGENT_LABEL_VALUE_STRING = "opentelemetry-java [0.6.0]";
-  private static final AttributeValue AGENT_LABEL_VALUE = AttributeValue.newBuilder()
-          .setStringValue(TruncatableString.newBuilder().setValue(AGENT_LABEL_VALUE_STRING).setTruncatedByteCount(0).build()).build();
-  private static final Span.Attributes ATTRIBUTES = Span.Attributes.newBuilder()
-          .setDroppedAttributesCount(0)
-          .putAttributeMap(AGENT_LABEL_KEY, AGENT_LABEL_VALUE)
-          .build();
-  private static final Span.TimeEvents TIME_EVENTS = Span.TimeEvents.newBuilder().build();
-  private static final io.opentelemetry.trace.Status SPAN_DATA_STATUS = io.opentelemetry.trace.Status.OK;
-  private static final Status SPAN_STATUS = Status.newBuilder().setCode(SPAN_DATA_STATUS.getCanonicalCode().value())
-          .build();
-  private static final Span.Links LINKS = Span.Links.newBuilder().setDroppedLinksCount(0).build();
+  private static final Status SPAN_DATA_STATUS = Status.OK;
+  private static final String LOCALHOST = "127.0.0.1";
 
-  @Mock
-  TraceServiceClient mockTraceServiceClient;
+  private MockTraceServiceClient mockTraceServiceClient;
   private TraceExporter exporter;
+  private Process mockServerProcess;
+
 
   @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
+  public void setup() throws IOException {
+    // Find a free port to spin up our server at.
+    ServerSocket socket = new ServerSocket(0);
+    int port = socket.getLocalPort();
+    String address = String.format("%s:%d", LOCALHOST, port);
+    socket.close();
+
+    // Start the mock server. This assumes the binary is present and in $PATH.
+    // Typically, the CI will be the one that curls the binary and adds it to $PATH.
+    String[] cmdArray = new String[]{"mock_server-x64-linux", "-address", address};
+    ProcessBuilder pb = new ProcessBuilder(cmdArray);
+    pb.redirectErrorStream(true);
+    mockServerProcess = pb.start();
+
+    // Setup the mock trace client.
+    mockTraceServiceClient = new MockTraceServiceClient(LOCALHOST, port);
+
+    // Block until the mock server starts (it will output the address after starting).
+    BufferedReader br = new BufferedReader(new InputStreamReader(mockServerProcess.getInputStream()));
+    br.readLine();
+  }
+
+  @After
+  public void tearDown() {
+    mockServerProcess.destroy();
   }
 
   @Test
@@ -71,13 +78,13 @@ public class EndToEndTest {
     exporter = new TraceExporter(PROJECT_ID, mockTraceServiceClient, FIXED_ATTRIBUTES);
     Collection<SpanData> spanDataList = new ArrayList<>();
 
-    SpanData spanDataOne = SpanData.newBuilder()
+    TestSpanData spanDataOne = TestSpanData.newBuilder()
             .setParentSpanId(PARENT_SPAN_ID)
             .setSpanId(SPAN_ID)
             .setTraceId(TRACE_ID)
             .setName(SPAN_NAME)
             .setKind(io.opentelemetry.trace.Span.Kind.SERVER)
-            .setTimedEvents(Collections.emptyList())
+            .setEvents(Collections.emptyList())
             .setStatus(SPAN_DATA_STATUS)
             .setStartEpochNanos(START_EPOCH_NANOS)
             .setEndEpochNanos(END_EPOCH_NANOS)
@@ -88,33 +95,8 @@ public class EndToEndTest {
 
     spanDataList.add(spanDataOne);
 
-    List<Span> expectedSpans = new ArrayList<>();
-    Span spanOne = Span.newBuilder()
-            .setName("projects/" + PROJECT_ID + "/traces/" + TRACE_ID.toLowerBase16() + "/spans/" + SPAN_ID.toLowerBase16())
-            .setSpanId(SPAN_ID.toLowerBase16())
-            .setDisplayName(TruncatableString.newBuilder().setValue(SERVER_PREFIX + SPAN_NAME).setTruncatedByteCount(0).build())
-            .setStartTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(START_SECONDS).setNanos(START_NANOS).build())
-            .setAttributes(ATTRIBUTES)
-            .setTimeEvents(TIME_EVENTS)
-            .setStatus(SPAN_STATUS)
-            .setEndTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(END_SECONDS).setNanos(END_NANOS).build())
-            .setLinks(LINKS)
-            .setParentSpanId(PARENT_SPAN_ID.toLowerBase16())
-            .setSameProcessAsParentSpan(BoolValue.of(true))
-            .build();
-    expectedSpans.add(spanOne);
-
-    // Instead of doReturn, doAnswer is better to deal with whenever batchWriteSpans() is called.
-    // Rather than actually call the BatchWriteSpans() method from the API, null is returned.
-    doAnswer(invocation -> null)
-            .when(mockTraceServiceClient).batchWriteSpans(eq(PROJECT_ID), anyList());
-
     // Invokes export();
     assertEquals(SpanExporter.ResultCode.SUCCESS, exporter.export(spanDataList));
-
-    // Make sure that the parameters passed to batchWriteSpans() are what we expect them to be
-    verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
-            eq(expectedSpans));
   }
 
   @Test
@@ -124,10 +106,5 @@ public class EndToEndTest {
 
     // Invokes export();
     assertEquals(SpanExporter.ResultCode.SUCCESS, exporter.export(spanDataList));
-    
-    List<Span> expectedSpans = new ArrayList<>();
-    verify(mockTraceServiceClient, times(1)).batchWriteSpans(eq(ProjectName.of(PROJECT_ID)),
-            eq(expectedSpans));
   }
-
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -106,7 +106,8 @@ public class TraceTranslatorTest {
     assertEquals(translatedAttributes.getAttributeMapMap().get("another").getStringValue().getValue(), "entry");
 
     assertTrue(translatedAttributes.containsAttributeMap("g.co/agent"));
-    assertEquals(translatedAttributes.getAttributeMapMap().get("g.co/agent").getStringValue().getValue(), "opentelemetry-java [0.6.0]");
+    assertEquals(translatedAttributes.getAttributeMapMap().get("g.co/agent").getStringValue().getValue(),
+            "opentelemetry-java 0.6.0; google-cloud-trace-exporter 0.1.0");
   }
 
   @Test

--- a/exporters/trace/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/exporters/trace/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
We'd like to integrate our [mock server](https://github.com/googleinterns/cloud-operations-api-mock) into the Java exporter to be used for integration testing.

Currently, the integration test just calls the mock server with the translated spans to verify that they follow the correct format and that the exporter has translated the spans properly. In the future, more tests can be added as needed.