### PR TITLE
Add an example project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,18 @@
 # Gradle
-/.gradle/
-/out/
+.gradle/
+out/
 .project
 .settings
 .classpath
 
-# IntelliJ IDEA
-/.idea/
-
-/.vscode/
+# IDE(A) files
+.idea/
+.settings/
+.vscode/
+.classpath
+.project
 
 # Build artifacts
-/exporters/trace/build/
-/exporters/trace/bin/
+build/
+bin/
 

--- a/examples/trace/build.gradle
+++ b/examples/trace/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'java'
+}
+
+description = 'Examples for Cloud Trace Exporter'
+
+dependencies {
+    compile(libraries.opentelemetry_api)
+    compile(libraries.opentelemetry_sdk)
+    compile(libraries.google_cloud_trace)
+    compile project(':exporter-trace')
+}

--- a/examples/trace/build.gradle
+++ b/examples/trace/build.gradle
@@ -2,18 +2,28 @@ plugins {
     id 'java'
 }
 
-//create a single Jar with all dependencies
-task fatJar(type: Jar) {
+jar {
     manifest {
-        attributes 'Main-Class': 'com.google.cloud.opentelemetry.example.trace.TraceExample'
+        attributes(
+                'Main-Class': 'com.google.cloud.opentelemetry.example.trace.TraceExample'
+        )
     }
-    archiveClassifier = "all"
+}
+
+
+task fatJar(type: Jar) {
+    manifest.from jar.manifest
+    archiveClassifier = 'all'
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    } {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
     }
     with jar
 }
+
 
 description = 'Examples for Cloud Trace Exporter'
 

--- a/examples/trace/build.gradle
+++ b/examples/trace/build.gradle
@@ -2,6 +2,19 @@ plugins {
     id 'java'
 }
 
+//create a single Jar with all dependencies
+task fatJar(type: Jar) {
+    manifest {
+        attributes 'Main-Class': 'com.google.cloud.opentelemetry.example.trace.TraceExample'
+    }
+    archiveClassifier = "all"
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    with jar
+}
+
 description = 'Examples for Cloud Trace Exporter'
 
 dependencies {

--- a/examples/trace/settings.gradle
+++ b/examples/trace/settings.gradle
@@ -1,0 +1,2 @@
+include "exporter-trace"
+project('exporter-trace').projectDir = new File('../../exporters/trace')

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
@@ -1,0 +1,51 @@
+package com.google.cloud.opentelemetry.example.trace;
+
+import com.google.cloud.opentelemetry.trace.TraceConfiguration;
+import com.google.cloud.opentelemetry.trace.TraceExporter;
+import com.google.cloud.trace.v2.TraceServiceClient;
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+//import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+
+import java.io.IOException;
+
+public class TraceExample {
+  private TraceExporter traceExporter;
+
+  // OTel API
+  private Tracer tracer = OpenTelemetry.getTracer("io.opentelemetry.example.TraceExample");
+
+  private void setupTraceExporter() {
+    
+    // using default configuration
+    TraceConfiguration configuration = TraceConfiguration.builder().build();
+
+//    OpenTelemetrySdk.getTracerProvider()
+//            .addSpanProcessor(SimpleSpansProcessor.newBuilder(this.traceExporter).build());
+  }
+
+  private void myUseCase() {
+    // Generate a span
+    Span span = this.tracer.spanBuilder("Start my wonderful use case").startSpan();
+    span.addEvent("Event 0");
+    // execute my use case - here we simulate a wait
+    doWork();
+    span.addEvent("Event 1");
+    span.end();
+  }
+
+  private void doWork() {
+    try {
+      Thread.sleep((int) (Math.random() * 1000) + 1000);
+    } catch (InterruptedException e) {
+    }
+  }
+
+  public static void main(String[] args) {
+    TraceExample example = new TraceExample();
+    example.setupTraceExporter();
+    // System.out.println("TODO: create some spans");
+  }
+}

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
@@ -2,12 +2,12 @@ package com.google.cloud.opentelemetry.example.trace;
 
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
-import com.google.cloud.trace.v2.TraceServiceClient;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-//import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Tracer;
+import java.time.Duration;
 
 import java.io.IOException;
 
@@ -19,11 +19,18 @@ public class TraceExample {
 
   private void setupTraceExporter() {
     
-    // using default configuration
-    TraceConfiguration configuration = TraceConfiguration.builder().build();
+    // using default project ID
+    TraceConfiguration configuration = TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
-//    OpenTelemetrySdk.getTracerProvider()
-//            .addSpanProcessor(SimpleSpansProcessor.newBuilder(this.traceExporter).build());
+    try {
+      this.traceExporter = TraceExporter.createWithConfiguration(configuration);
+    } catch(IOException e) {
+      System.out.println("Uncaught Excetption");
+    }
+
+    OpenTelemetrySdk.getTracerProvider()
+            .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
+    System.out.println("Done");
   }
 
   private void myUseCase() {
@@ -46,6 +53,12 @@ public class TraceExample {
   public static void main(String[] args) {
     TraceExample example = new TraceExample();
     example.setupTraceExporter();
-    // System.out.println("TODO: create some spans");
+
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+    }
+    System.out.println("Done");
+
   }
 }

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
@@ -2,6 +2,7 @@ package com.google.cloud.opentelemetry.example.trace;
 
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
+import com.google.cloud.trace.v2.TraceServiceClient;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.trace.Span;
@@ -30,7 +31,7 @@ public class TraceExample {
 
     OpenTelemetrySdk.getTracerProvider()
             .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
-    System.out.println("Done");
+    System.out.println("Set up");
   }
 
   private void myUseCase() {

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
@@ -2,7 +2,6 @@ package com.google.cloud.opentelemetry.example.trace;
 
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
-import com.google.cloud.trace.v2.TraceServiceClient;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.trace.Span;
@@ -15,30 +14,28 @@ import java.io.IOException;
 public class TraceExample {
   private TraceExporter traceExporter;
 
-  // OTel API
   private Tracer tracer = OpenTelemetry.getTracer("io.opentelemetry.example.TraceExample");
 
   private void setupTraceExporter() {
-    
     // using default project ID
     TraceConfiguration configuration = TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
     try {
       this.traceExporter = TraceExporter.createWithConfiguration(configuration);
+
+      OpenTelemetrySdk.getTracerProvider()
+              .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
     } catch(IOException e) {
       System.out.println("Uncaught Excetption");
     }
 
-    OpenTelemetrySdk.getTracerProvider()
-            .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
-    System.out.println("Set up");
   }
 
   private void myUseCase() {
-    // Generate a span
-    Span span = this.tracer.spanBuilder("Start my wonderful use case").startSpan();
+    // generate a span
+    Span span = this.tracer.spanBuilder("Start my use case").startSpan();
     span.addEvent("Event 0");
-    // execute my use case - here we simulate a wait
+    // simulate work
     doWork();
     span.addEvent("Event 1");
     span.end();
@@ -55,11 +52,14 @@ public class TraceExample {
     TraceExample example = new TraceExample();
     example.setupTraceExporter();
 
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
+    while(true) {
+      example.myUseCase();
+      try {
+        // one hour
+        Thread.sleep(1000 * 60 * 60);
+      } catch (InterruptedException e) {
+      }
     }
-    System.out.println("Done");
 
   }
 }

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExample.java
@@ -4,12 +4,12 @@ import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import java.time.Duration;
 
 import java.io.IOException;
+import java.time.Duration;
 
 public class TraceExample {
   private TraceExporter traceExporter;
@@ -18,17 +18,17 @@ public class TraceExample {
 
   private void setupTraceExporter() {
     // using default project ID
-    TraceConfiguration configuration = TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
+    TraceConfiguration configuration =
+        TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
     try {
       this.traceExporter = TraceExporter.createWithConfiguration(configuration);
 
       OpenTelemetrySdk.getTracerProvider()
-              .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
-    } catch(IOException e) {
+          .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
+    } catch (IOException e) {
       System.out.println("Uncaught Excetption");
     }
-
   }
 
   private void myUseCase() {
@@ -52,7 +52,7 @@ public class TraceExample {
     TraceExample example = new TraceExample();
     example.setupTraceExporter();
 
-    while(true) {
+    while (true) {
       example.myUseCase();
       try {
         // one hour
@@ -60,6 +60,5 @@ public class TraceExample {
       } catch (InterruptedException e) {
       }
     }
-
   }
 }

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -17,17 +17,18 @@ public class TraceExporterExample {
   private Tracer tracer = OpenTelemetry.getTracer("io.opentelemetry.example.TraceExporterExample");
 
   private void setupTraceExporter() {
-    // using default project ID
+    // Using default project ID and Credentials
     TraceConfiguration configuration =
         TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
     try {
       this.traceExporter = TraceExporter.createWithConfiguration(configuration);
 
+      // Register the TraceExporter with OpenTelemetry
       OpenTelemetrySdk.getTracerProvider()
           .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
     } catch (IOException e) {
-      System.out.println("Uncaught Excetption");
+      System.out.println("Uncaught Exception");
     }
   }
 
@@ -35,8 +36,9 @@ public class TraceExporterExample {
     // Generate a span
     Span span = this.tracer.spanBuilder("Start my use case").startSpan();
     span.addEvent("Event 0");
-    // Simulate work
+    // Simulate work: this could be simulating a network request or an expensive disk operation
     doWork();
+
     span.addEvent("Event 1");
     span.end();
   }
@@ -45,6 +47,7 @@ public class TraceExporterExample {
     try {
       Thread.sleep((int) (Math.random() * 1000) + 1000);
     } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -11,10 +11,10 @@ import io.opentelemetry.trace.Tracer;
 import java.io.IOException;
 import java.time.Duration;
 
-public class TraceExample {
+public class TraceExporterExample {
   private TraceExporter traceExporter;
 
-  private Tracer tracer = OpenTelemetry.getTracer("io.opentelemetry.example.TraceExample");
+  private Tracer tracer = OpenTelemetry.getTracer("io.opentelemetry.example.TraceExporterExample");
 
   private void setupTraceExporter() {
     // using default project ID
@@ -32,10 +32,10 @@ public class TraceExample {
   }
 
   private void myUseCase() {
-    // generate a span
+    // Generate a span
     Span span = this.tracer.spanBuilder("Start my use case").startSpan();
     span.addEvent("Event 0");
-    // simulate work
+    // Simulate work
     doWork();
     span.addEvent("Event 1");
     span.end();
@@ -49,16 +49,8 @@ public class TraceExample {
   }
 
   public static void main(String[] args) {
-    TraceExample example = new TraceExample();
+    TraceExporterExample example = new TraceExporterExample();
     example.setupTraceExporter();
-
-    while (true) {
-      example.myUseCase();
-      try {
-        // one hour
-        Thread.sleep(1000 * 60 * 60);
-      } catch (InterruptedException e) {
-      }
-    }
+    example.myUseCase();
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,10 @@
 rootProject.name = "opentelemetry-operations-java"
 
 include ":exporter-trace"
+include ":examples-trace"
 
 project(':exporter-trace').projectDir =
         "$rootDir/exporters/trace" as File
+
+project(':examples-trace').projectDir =
+       "$rootDir/examples/trace" as File


### PR DESCRIPTION
# Context
Right now customer don't have any way to see how to use our exporter

# Solution 
Create a TraceExample project with some sample code that customers can use. This involves a new gradle project with `build.gradle` and dependencies

# Test plan
Automatic tests
```sh
$ gradle test && gradle build
```
In addition I tested this project by deploying it to GKE using the following dockerfile
```dockerfile
FROM openjdk:8
VOLUME /tmp
RUN mkdir /application
COPY . /application
WORKDIR /application
RUN /application/gradlew build
RUN /application/gradlew clean build examples-trace:fatJar #if you use maven you can change to mvnw
RUN mv examples/trace/build/libs/examples-trace-0.0.0-SNAPSHOT-all.jar /application/app.jar
ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/application/app.jar"]
```
And list of commands
```sh
docker build --no-cache -t traceexample . &&
gcloud container clusters create traceexample-cluster --num-nodes=3 --region=us-central1-a &&
gcloud builds submit --tag=gcr.io/noahcook/traceexample:v1 . &&
gcloud config set container/cluster traceexample-cluster &&
kubectl run traceexample --image=gcr.io/noahcook/traceexample:v1 --port 8080 &&
kubectl get pods &&
kubectl expose deployment traceexample --type=LoadBalancer --port 80 --target-port 8080 &&
kubectl get service
```
The stuff about the ports is because I used this deploy script for a different project.
After being deployed the traces show up on gcloud.

# Future Work
I'll also need to add a ReadMe for this, but I'll wait until this is merged
