### PR TITLE
Create a method for creating a trace exporter with default configuration

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -28,6 +28,11 @@ public class TraceExporter implements SpanExporter {
   private final String projectId;
   private final Map<String, AttributeValue> fixedAttributes;
 
+  public static TraceExporter createWithDefaultConfiguration() throws IOException {
+    TraceConfiguration configuration = TraceConfiguration.builder().build();
+    return TraceExporter.createWithConfiguration(configuration);
+  }
+
   public static TraceExporter createWithConfiguration(TraceConfiguration configuration)
       throws IOException {
     String projectId = configuration.getProjectId();


### PR DESCRIPTION
# Context
I think that it will be a common pattern to create TraceExporters using the default configuration, but right now it would take 2 lines of code to do so

# Solution
Create a method for using the default configuration, saving developers a little bit of time.

# Test plan
```sh
$ gradle build && gradle test
```