### PR TITLE
EZ: add shutdown method to 

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CloudTraceClient {
   void batchWriteSpans(ProjectName name, List<Span> spans);
+
+  void shutdown();
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
@@ -6,5 +6,5 @@ import com.google.devtools.cloudtrace.v2.Span;
 import java.util.List;
 
 public interface CloudTraceClient {
-    void batchWriteSpans(ProjectName name, List<Span> spans);
+  void batchWriteSpans(ProjectName name, List<Span> spans);
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
@@ -7,13 +7,13 @@ import com.google.devtools.cloudtrace.v2.Span;
 import java.util.List;
 
 public class CloudTraceClientImpl implements CloudTraceClient {
-    private final TraceServiceClient traceServiceClient;
+  private final TraceServiceClient traceServiceClient;
 
-    public CloudTraceClientImpl(TraceServiceClient traceServiceClient) {
-        this.traceServiceClient = traceServiceClient;
-    }
+  public CloudTraceClientImpl(TraceServiceClient traceServiceClient) {
+    this.traceServiceClient = traceServiceClient;
+  }
 
-    public final void batchWriteSpans(ProjectName name, List<Span> spans) {
-        traceServiceClient.batchWriteSpans(name, spans);
-    }
+  public final void batchWriteSpans(ProjectName name, List<Span> spans) {
+    this.traceServiceClient.batchWriteSpans(name, spans);
+  }
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
@@ -16,4 +16,8 @@ public class CloudTraceClientImpl implements CloudTraceClient {
   public final void batchWriteSpans(ProjectName name, List<Span> spans) {
     this.traceServiceClient.batchWriteSpans(name, spans);
   }
+
+  public final void shutdown() {
+    this.traceServiceClient.shutdown();
+  }
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
@@ -10,25 +10,22 @@ import io.grpc.ManagedChannelBuilder;
 import java.util.List;
 
 // A simplified version of TraceServiceClient, used ONLY for testing purposes.
-class MockCloudTraceClient implements CloudTraceClient{
+class MockCloudTraceClient implements CloudTraceClient {
 
-    private final TraceServiceGrpc.TraceServiceBlockingStub blockingStub;
+  private final TraceServiceGrpc.TraceServiceBlockingStub blockingStub;
 
-    MockCloudTraceClient(String host, int port) {
-        this(ManagedChannelBuilder.forAddress(host, port).usePlaintext());
-    }
+  MockCloudTraceClient(String host, int port) {
+    this(ManagedChannelBuilder.forAddress(host, port).usePlaintext());
+  }
 
-    private MockCloudTraceClient(ManagedChannelBuilder<?> channelBuilder) {
-        Channel channel = channelBuilder.build();
-        blockingStub = TraceServiceGrpc.newBlockingStub(channel);
-    }
+  private MockCloudTraceClient(ManagedChannelBuilder<?> channelBuilder) {
+    Channel channel = channelBuilder.build();
+    blockingStub = TraceServiceGrpc.newBlockingStub(channel);
+  }
 
-    public final void batchWriteSpans(ProjectName name, List<Span> spans) {
-        BatchWriteSpansRequest request =
-                BatchWriteSpansRequest.newBuilder()
-                        .setName(name.toString())
-                        .addAllSpans(spans)
-                        .build();
-        blockingStub.batchWriteSpans(request);
-    }
+  public final void batchWriteSpans(ProjectName name, List<Span> spans) {
+    BatchWriteSpansRequest request =
+        BatchWriteSpansRequest.newBuilder().setName(name.toString()).addAllSpans(spans).build();
+    blockingStub.batchWriteSpans(request);
+  }
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
@@ -28,4 +28,7 @@ class MockCloudTraceClient implements CloudTraceClient {
         BatchWriteSpansRequest.newBuilder().setName(name.toString()).addAllSpans(spans).build();
     blockingStub.batchWriteSpans(request);
   }
+
+  // Empty because not being tested
+  public final void shutdown() {}
 }

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -105,6 +105,6 @@ public class TraceExporter implements SpanExporter {
 
   @Override
   public void shutdown() {
-    throw new UnsupportedOperationException();
+    this.cloudTraceClient.shutdown();
   }
 }


### PR DESCRIPTION
# Context
I found a shutdown method in TraceServiceClient, and we don't currently support shutdown.
# Solution
Add a shutdown method to `CloudTraceClient`, and call it within `TraceExporter`
# Test plan
1. Run google java formatter
2. 
```sh
$ gradle build && gradle test
```