### PR TITLE
Change SimpleSpanProcessor to BatchSpanProcessor in example

### DIFF
--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -4,7 +4,7 @@ import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 
@@ -26,7 +26,7 @@ public class TraceExporterExample {
 
       // Register the TraceExporter with OpenTelemetry
       OpenTelemetrySdk.getTracerProvider()
-          .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.traceExporter).build());
+          .addSpanProcessor(BatchSpanProcessor.newBuilder(this.traceExporter).build());
     } catch (IOException e) {
       System.out.println("Uncaught Exception");
     }


### PR DESCRIPTION
# Context
`SimpleSpanProcessor` shouldn't be used in production, so I'm changing it to `BatchSpanProcessor` in the example

# Solution
Change the `SimpleSpanProcessor` to `BatchSpanProcessor` in the example

# Test plan
```sh
$ gradle build && gradle test
```
I didn't deploy it because that's a sizable amount of work, but I can deploy it if you think it needs to be tested.