### PR TITLE
Configure gradle to publish to OSSRH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 subprojects {
     apply plugin: 'java-library'
+    apply plugin: 'maven'
+    apply plugin: 'signing'
 
     group = "com.google.cloud.opentelemetry.operations"
     version = "0.0.0-SNAPSHOT" // CURRENT_VERSION
@@ -21,15 +23,80 @@ subprojects {
 
         libraries = [
                 auto_value_annotations: "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
-                auto_value: "com.google.auto.value:auto-value:${autoValueVersion}",
-                google_cloud_core: "com.google.cloud:google-cloud-core:${googleCloudVersion}",
-                google_cloud_grpc: "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleCloudVersion}",
-                google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
-                opentelemetry_api:"io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
-                opentelemetry_sdk:"io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
+                auto_value            : "com.google.auto.value:auto-value:${autoValueVersion}",
+                google_cloud_core     : "com.google.cloud:google-cloud-core:${googleCloudVersion}",
+                google_cloud_grpc     : "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleCloudVersion}",
+                google_cloud_trace    : "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
+                opentelemetry_api     : "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
+                opentelemetry_sdk     : "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
         ]
         testLibraries = [
-                junit:"junit:junit:${junitVersion}",
+                junit: "junit:junit:${junitVersion}",
         ]
+    }
+
+    task javadocJar(type: Jar) {
+        archiveClassifier = 'javadoc'
+        from javadoc
+    }
+
+    task sourcesJar(type: Jar) {
+        archiveClassifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    artifacts {
+        archives javadocJar, sourcesJar
+    }
+
+    signing {
+        sign configurations.archives
+    }
+
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                def configureAuth = {
+                    if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
+                        authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
+                    }
+                }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/")
+
+                pom.project {
+                    name 'Opentelemetry Operations Java'
+                    packaging 'jar'
+                    url 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+
+                    scm {
+                        connection 'scm:svn:http://foo.googlecode.com/svn/trunk/'
+                        developerConnection 'scm:svn:https://foo.googlecode.com/svn/trunk/'
+                        url 'http://foo.googlecode.com/svn/trunk/'
+                    }
+
+                    licenses {
+                        license {
+                            name 'The Apache License, Version 2.0'
+                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'io.opentelemetry'
+                            name 'Opentelemetry Contributors'
+                            email 'opentelemetry-team@google.com'
+                            organization = 'OpenTelemetry Authors'
+                            organizationUrl 'https://www.opentelemetry.io'
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,11 +89,11 @@ subprojects {
 
                     developers {
                         developer {
-                            id 'io.opentelemetry'
-                            name 'Opentelemetry Contributors'
+                            id 'com.google.cloud.opentelemetry'
+                            name 'OpenTelemetry Operations Contributors'
                             email 'opentelemetry-team@google.com'
-                            organization = 'OpenTelemetry Authors'
-                            organizationUrl 'https://www.opentelemetry.io'
+                            organization = 'Google Inc'
+                            organizationUrl 'https://cloud.google.com/products/operations'
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,9 @@ subprojects {
                     url 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
 
                     scm {
-                        connection 'scm:svn:http://foo.googlecode.com/svn/trunk/'
-                        developerConnection 'scm:svn:https://foo.googlecode.com/svn/trunk/'
-                        url 'http://foo.googlecode.com/svn/trunk/'
+                        connection 'scm:svn:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+                        developerConnection 'scm:svn:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+                        url 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
                     }
 
                     licenses {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'signing'
 
-    group = "com.google.cloud.opentelemetry.operations"
+    group = "com.google.cloud.opentelemetry"
     version = "0.0.0-SNAPSHOT" // CURRENT_VERSION
 
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -50,6 +50,7 @@ subprojects {
     }
 
     signing {
+        required false
         sign configurations.archives
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
         autoValueVersion = '1.7.4'
         googleCloudVersion = '1.0.2'
         openTelemetryVersion = '0.6.0'
-        junitVersion = '4.13';
+        junitVersion = '4.13'
 
         libraries = [
                 auto_value_annotations: "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
@@ -36,12 +36,12 @@ subprojects {
     }
 
     task javadocJar(type: Jar) {
-        archiveClassifier = 'javadoc'
+        archiveClassifier.set('javadoc')
         from javadoc
     }
 
     task sourcesJar(type: Jar) {
-        archiveClassifier = 'sources'
+        archiveClassifier.set('sources')
         from sourceSets.main.allSource
     }
 
@@ -64,9 +64,9 @@ subprojects {
                     }
                 }
 
-                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/", configureAuth)
 
-                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/")
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/", configureAuth)
 
                 pom.project {
                     name 'Opentelemetry Operations Java'


### PR DESCRIPTION
This allows `gradle uploadArchives` to be run to upload artefacts to https://oss.sonatype.org/content/repositories/snapshots/com/google/cloud/opentelemetry/.

Issue: #6