### PR TITLE
Start 0.8.0 development cycle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     apply plugin: 'signing'
 
     group = "com.google.cloud.opentelemetry"
-    version = "0.0.0-SNAPSHOT" // CURRENT_VERSION
+    version = "0.8.0-SNAPSHOT" // CURRENT_VERSION
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Bump master to the next version. 

Please don't merge this until the 0.7.0 deployment is released to the Central Repository.