### PR TITLE
Refactor: CircleCI: Move docker and setup/teardown tasks to sharable …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,20 @@ commands:
 jobs:
   build:
     executor: jdk
+    steps:
+      - setup
+
+      - run:
+          name: Build jars
+          command: ./gradlew sourcesJar
+
+      - teardown
+
+      - store_artifacts:
+          path: ./exporters/trace/build
+
+  test:
+    executor: jdk
 
     steps:
       - setup
@@ -51,3 +65,10 @@ jobs:
 
       - store_artifacts:
           path: /home/circleci/project/exporters/trace/build/reports/jacoco/test
+
+workflows:
+  version: 2
+  build-test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,13 @@
 # Orb 'circleci/gradle@2.2.0' resolved to 'circleci/gradle@2.2.0'
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  jdk:
     docker:
       - image: cimg/openjdk:13.0
 
+commands:
+  setup:
     steps:
       - checkout
 
@@ -14,6 +17,21 @@ jobs:
 
       - restore_cache:
           key: gradle-v1-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
+
+  teardown:
+    steps:
+      - save_cache:
+          key: gradle-v1-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+
+jobs:
+  build:
+    executor: jdk
+
+    steps:
+      - setup
 
       - run:
           command: chmod +x ./get_mock_server.sh && ./get_mock_server.sh
@@ -26,11 +44,7 @@ jobs:
           name: Run Tests
           working_directory: ''
 
-      - save_cache:
-          key: gradle-v1-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
+      - teardown
 
       - store_test_results:
           path: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,11 @@ jobs:
 
       - store_artifacts:
           path: ./exporters/trace/build
+      - store_artifacts:
+          path: ./exporters/metrics/build
 
   test:
     executor: jdk
-
     steps:
       - setup
 


### PR DESCRIPTION
# Motivation

While working in this repo, I've been _slightly_ hindered by needing a built jar but having to jump through a few hoops to get it loaded somewhere my Docker containers, etc. etc. can get access to it.

The [OpenTelemetry-Java-Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/.circleci/config.yml#L45-L46) repo has some tooling around this which makes it super easy to snag a built jar to test in an environment. Since this isn't uploaded to an actual Maven repo etc., this doesn't interfere with normal release cycles, but rather puts the onus on users with some basic `curl` commands and CircleCI for the hosting.

## Suggested Musical Pairing

https://soundcloud.com/dabilliondollarbaby/vibez