### PR TITLE
Temporarily remove timeseries resource

### DIFF
--- a/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricExporter.java
+++ b/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricExporter.java
@@ -4,10 +4,9 @@ import static com.google.api.client.util.Preconditions.checkNotNull;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetric;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetricDescriptor;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapPoint;
+import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapResource;
 
-import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
-import com.google.api.MonitoredResource;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -131,7 +130,6 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
         continue;
       }
 
-      Metric metric = mapMetric(metricPoint, descriptor.getType());
       Point point = mapPoint(metricData, metricPoint, updateKey, lastUpdatedTime);
       if (point == null) {
         continue;
@@ -139,10 +137,10 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
 
       allTimesSeries.add(
           TimeSeries.newBuilder()
-              .setMetric(metric)
-              .addPoints(point)
-              .setResource(MonitoredResource.newBuilder().build())
+              .setMetric(mapMetric(metricPoint, descriptor.getType()))
               .setMetricKind(descriptor.getMetricKind())
+              .setResource(mapResource(metricData.getResource()))
+              .addPoints(point)
               .build());
     }
     createTimeSeriesBatch(metricServiceClient, ProjectName.of(projectId), allTimesSeries);

--- a/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricExporter.java
+++ b/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricExporter.java
@@ -4,7 +4,6 @@ import static com.google.api.client.util.Preconditions.checkNotNull;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetric;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetricDescriptor;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapPoint;
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapResource;
 
 import com.google.api.MetricDescriptor;
 import com.google.api.gax.core.FixedCredentialsProvider;
@@ -139,7 +138,6 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
           TimeSeries.newBuilder()
               .setMetric(mapMetric(metricPoint, descriptor.getType()))
               .setMetricKind(descriptor.getMetricKind())
-              .setResource(mapResource(metricData.getResource()))
               .addPoints(point)
               .build());
     }

--- a/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com.google.cloud.opentelemetry.metric/MetricTranslator.java
@@ -8,7 +8,6 @@ import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LO
 import com.google.api.LabelDescriptor;
 import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
-import com.google.api.MonitoredResource;
 import com.google.cloud.opentelemetry.metric.MetricExporter.MetricWithLabels;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Longs;
@@ -17,11 +16,8 @@ import com.google.monitoring.v3.Point.Builder;
 import com.google.monitoring.v3.TimeInterval;
 import com.google.monitoring.v3.TypedValue;
 import com.google.protobuf.Timestamp;
-import io.opentelemetry.api.common.AttributeConsumer;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Type;
-import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -127,20 +123,6 @@ public class MetricTranslator {
     Timestamp startTime = mapTimestamp(point.getStartEpochNanos());
     Timestamp endTime = mapTimestamp(point.getEpochNanos());
     return TimeInterval.newBuilder().setStartTime(startTime).setEndTime(endTime).build();
-  }
-
-  static MonitoredResource mapResource(Resource resource) {
-    MonitoredResource.Builder resourceBuilder = MonitoredResource.newBuilder();
-    resource
-        .getAttributes()
-        .forEach(
-            new AttributeConsumer() {
-              @Override
-              public <T> void accept(AttributeKey<T> key, T value) {
-                resourceBuilder.putLabels(key.getKey(), String.valueOf(value));
-              }
-            });
-    return resourceBuilder.build();
   }
 
   private static Timestamp mapTimestamp(long epochNanos) {

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -23,9 +23,7 @@ import com.google.api.LabelDescriptor.ValueType;
 import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
 import com.google.api.MetricDescriptor.MetricKind;
-import com.google.api.MonitoredResource;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.ProjectName;
@@ -121,22 +119,6 @@ public class MetricExporterTest {
                     .putLabels("label2", "False")
                     .build())
             .addPoints(expectedPoint)
-            .setResource(
-                MonitoredResource.newBuilder()
-                    .putAllLabels(
-                        ImmutableMap.of(
-                            "cloud.account.id",
-                            "123",
-                            "cloud.provider",
-                            "gcp",
-                            "cloud.zone",
-                            "US",
-                            "extra_info",
-                            "extra",
-                            "host.id",
-                            "host"))
-                    .putLabels("not_gcp_resource", "value")
-                    .build())
             .setMetricKind(expectedDescriptor.getMetricKind())
             .build();
     CreateMetricDescriptorRequest expectedRequest =

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -25,6 +25,7 @@ import com.google.api.MetricDescriptor;
 import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.MonitoredResource;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.ProjectName;
@@ -120,7 +121,22 @@ public class MetricExporterTest {
                     .putLabels("label2", "False")
                     .build())
             .addPoints(expectedPoint)
-            .setResource(MonitoredResource.newBuilder().build())
+            .setResource(
+                MonitoredResource.newBuilder()
+                    .putAllLabels(
+                        ImmutableMap.of(
+                            "cloud.account.id",
+                            "123",
+                            "cloud.provider",
+                            "gcp",
+                            "cloud.zone",
+                            "US",
+                            "extra_info",
+                            "extra",
+                            "host.id",
+                            "host"))
+                    .putLabels("not_gcp_resource", "value")
+                    .build())
             .setMetricKind(expectedDescriptor.getMetricKind())
             .build();
     CreateMetricDescriptorRequest expectedRequest =


### PR DESCRIPTION
This will hopefully resolve https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/46 and https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/57

Removing resource from timeseries altogether for now, as it isn't properly mapped. https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/40 will track the resource mapping issue.