### PR TITLE
Fix and improve the example code

### DIFF
--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -5,55 +5,72 @@ import com.google.cloud.opentelemetry.trace.TraceExporter;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Random;
 
 public class TraceExporterExample {
-  private TraceExporter traceExporter;
+  private static final Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.example.TraceExporterExample");
+  private static final Random random = new Random();
 
-  private Tracer tracer =
-      OpenTelemetry.getGlobalTracer("io.opentelemetry.example.TraceExporterExample");
-
-  private void setupTraceExporter() {
+  private static void setupTraceExporter() {
     // Using default project ID and Credentials
     TraceConfiguration configuration =
         TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
     try {
-      this.traceExporter = TraceExporter.createWithConfiguration(configuration);
+      TraceExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
 
       // Register the TraceExporter with OpenTelemetry
       OpenTelemetrySdk.getGlobalTracerManagement()
-          .addSpanProcessor(SimpleSpanProcessor.builder(this.traceExporter).build());
+          .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build());
     } catch (IOException e) {
       System.out.println("Uncaught Exception");
     }
   }
 
-  private void myUseCase() {
+  private static void myUseCase(String description) {
     // Generate a span
-    Span span = this.tracer.spanBuilder("Start my use case").startSpan();
-    span.addEvent("Event 0");
-    // Simulate work: this could be simulating a network request or an expensive disk operation
-    doWork();
+    Span span = tracer.spanBuilder(description).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      span.addEvent("Event A");
+      // Do some work for the use case
+      for (int i=0; i<3; i++) {
+        String work = String.format("%s - Work #%d", description, (i+1));
+        doWork(work);
+      }
 
-    span.addEvent("Event 1");
-    span.end();
+      span.addEvent("Event B");
+    } finally {
+      span.end();
+    }
   }
 
-  private void doWork() {
-    try {
-      Thread.sleep((int) (Math.random() * 1000) + 1000);
+  private static void doWork(String description) {
+    // Child span
+    Span span = tracer.spanBuilder(description).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      // Simulate work: this could be simulating a network request or an expensive disk operation
+      Thread.sleep(100 + random.nextInt(5) * 100);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    } finally {
+      span.end();
     }
   }
 
   public static void main(String[] args) {
-    TraceExporterExample example = new TraceExporterExample();
-    example.setupTraceExporter();
-    example.myUseCase();
+    // Configure the OpenTelemetry pipeline with CloudTrace exporter
+    setupTraceExporter();
+
+    // Application-specific logic
+    myUseCase("One");
+    myUseCase("Two");
+
+    // Flush all buffered traces
+    OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
   }
 }


### PR DESCRIPTION
- Use scopes
- Produce child spans
- Invoke `shutdown()` on exit to flush traces