### PR TITLE
Resolving API breaking changes from 0.11.0 to 0.13.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     apply plugin: 'signing'
 
     group = "com.google.cloud.opentelemetry"
-    version = "0.12.0-SNAPSHOT" // CURRENT_VERSION
+    version = "0.13.1-SNAPSHOT" // CURRENT_VERSION
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -23,8 +23,8 @@ subprojects {
         slf4jVersion = '1.7.30'
         googleCloudVersion = '1.0.2'
         cloudMonitoringVersion = '2.0.1'
-        openTelemetryVersion = '0.11.0'
-        openTelemetryInstrumentationVersion = '0.11.0'
+        openTelemetryVersion = '0.13.1'
+        openTelemetryInstrumentationVersion = '0.13.1'
         junitVersion = '4.13'
         mockitoVersion = '3.5.10'
 

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricExporter.java
@@ -173,8 +173,10 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
   }
 
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     metricServiceClient.shutdown();
+
+    return CompletableResultCode.ofSuccess();
   }
 
   static class MetricWithLabels {

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
@@ -1,9 +1,9 @@
 package com.google.cloud.opentelemetry.metric;
 
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE;
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG;
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE;
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG;
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.DOUBLE_GAUGE;
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.DOUBLE_SUM;
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.LONG_GAUGE;
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.LONG_SUM;
 
 import com.google.api.LabelDescriptor;
 import com.google.api.Metric;
@@ -37,10 +37,10 @@ public class MetricTranslator {
   static final long NANO_PER_SECOND = (long) 1e9;
   static final String METRIC_DESCRIPTOR_TIME_UNIT = "ns";
 
-  static final Set<Type> GAUGE_TYPES = ImmutableSet.of(NON_MONOTONIC_LONG, NON_MONOTONIC_DOUBLE);
-  static final Set<Type> CUMULATIVE_TYPES = ImmutableSet.of(MONOTONIC_LONG, MONOTONIC_DOUBLE);
-  static final Set<Type> LONG_TYPES = ImmutableSet.of(NON_MONOTONIC_LONG, MONOTONIC_LONG);
-  static final Set<Type> DOUBLE_TYPES = ImmutableSet.of(NON_MONOTONIC_DOUBLE, MONOTONIC_DOUBLE);
+  static final Set<Type> GAUGE_TYPES = ImmutableSet.of(LONG_GAUGE, DOUBLE_GAUGE);
+  static final Set<Type> CUMULATIVE_TYPES = ImmutableSet.of(LONG_SUM, DOUBLE_SUM);
+  static final Set<Type> LONG_TYPES = ImmutableSet.of(LONG_GAUGE, LONG_SUM);
+  static final Set<Type> DOUBLE_TYPES = ImmutableSet.of(DOUBLE_GAUGE, DOUBLE_SUM);
   private static final int MIN_TIMESTAMP_INTERVAL_NANOS = 1000000;
 
   static Metric mapMetric(MetricData.Point metricPoint, String type) {

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -48,17 +48,26 @@ public class FakeData {
           Labels.of("label1", "value1", "label2", "False"),
           32L);
 
+  static final Point aDoublePoint =
+          MetricData.DoublePoint.create(
+                  1599030114 * NANO_PER_SECOND,
+                  1599031814 * NANO_PER_SECOND,
+                  Labels.of("label1", "value1", "label2", "False"),
+                  32d);
+
   // The name does not have to start with "opentelemetry/", it is set this way because of a bug in
   // the mock server,
   // and should be changed when the following issue is resolved:
   // https://github.com/googleinterns/cloud-operations-api-mock/issues/56
   static final MetricData aMetricData =
-      MetricData.create(
+      MetricData.createLongSum(
           aGceResource,
           anInstrumentationLibraryInfo,
           "opentelemetry/name",
           "description",
           "ns",
-          Type.MONOTONIC_LONG,
-          ImmutableList.of(aLongPoint));
+              MetricData.LongSumData.create(
+                      true,
+                      MetricData.AggregationTemporality.CUMULATIVE,
+                      ImmutableList.of(aLongPoint)));
 }

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -3,6 +3,7 @@ package com.google.cloud.opentelemetry.metric;
 import static com.google.cloud.opentelemetry.metric.FakeData.aFakeCredential;
 import static com.google.cloud.opentelemetry.metric.FakeData.aGceResource;
 import static com.google.cloud.opentelemetry.metric.FakeData.aLongPoint;
+import static com.google.cloud.opentelemetry.metric.FakeData.aDoublePoint;
 import static com.google.cloud.opentelemetry.metric.FakeData.aMetricData;
 import static com.google.cloud.opentelemetry.metric.FakeData.aProjectId;
 import static com.google.cloud.opentelemetry.metric.FakeData.anInstrumentationLibraryInfo;
@@ -153,14 +154,13 @@ public class MetricExporterTest {
     MetricExporter exporter = MetricExporter.createWithClient(aProjectId, mockClient);
 
     MetricData metricData =
-        MetricData.create(
+        MetricData.createDoubleSummary(
             aGceResource,
             anInstrumentationLibraryInfo,
             "Metric Name",
             "description",
             "ns",
-            Type.SUMMARY,
-            ImmutableList.of(aLongPoint));
+            MetricData.DoubleSummaryData.create(ImmutableList.of(aDoublePoint)));
 
     CompletableResultCode result = exporter.export(ImmutableList.of(metricData));
     verify(mockClient, times(0)).createMetricDescriptor(any());

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
@@ -1,6 +1,7 @@
 package com.google.cloud.opentelemetry.metric;
 
 import static com.google.cloud.opentelemetry.metric.FakeData.aGceResource;
+import static com.google.cloud.opentelemetry.metric.FakeData.aDoublePoint;
 import static com.google.cloud.opentelemetry.metric.FakeData.aLongPoint;
 import static com.google.cloud.opentelemetry.metric.FakeData.aMetricData;
 import static com.google.cloud.opentelemetry.metric.FakeData.anInstrumentationLibraryInfo;
@@ -69,14 +70,13 @@ public class MetricTranslatorTest {
     String description = "Metric Description";
     String unit = "ns";
     MetricData metricData =
-        MetricData.create(
+        MetricData.createDoubleSummary(
             aGceResource,
             anInstrumentationLibraryInfo,
             name,
             description,
             unit,
-            Type.SUMMARY,
-            ImmutableList.of(aLongPoint));
+            MetricData.DoubleSummaryData.create(ImmutableList.of(aDoublePoint)));
 
     MetricDescriptor actualDescriptor =
         MetricTranslator.mapMetricDescriptor(metricData, aLongPoint);

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
@@ -58,6 +58,7 @@ public abstract class TestSpanData implements SpanData {
   public static Builder newBuilder() {
     return new AutoValue_TestSpanData.Builder()
         .setParentSpanId(SpanId.getInvalid())
+        .setParentSpanContext(SpanContext.getInvalid())
         .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty())
         .setLinks(Collections.emptyList())
         .setTotalRecordedLinks(0)

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
@@ -26,17 +26,17 @@ package com.google.cloud.opentelemetry.trace;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
+
+import javax.annotation.concurrent.Immutable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.concurrent.Immutable;
 
 /**
  * Immutable representation of all data collected by the {@link io.opentelemetry.api.trace.Span}
@@ -200,7 +200,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this
      * @since 0.1.0
      */
-    public abstract Builder setAttributes(ReadableAttributes attributes);
+    public abstract Builder setAttributes(Attributes attributes);
 
     /**
      * Set timed events that are associated with this span. Must not be null, may be empty.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TestSpanData.java
@@ -27,6 +27,7 @@ package com.google.cloud.opentelemetry.trace;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -73,6 +74,9 @@ public abstract class TestSpanData implements SpanData {
   abstract boolean getInternalHasEnded();
 
   abstract boolean getInternalHasRemoteParent();
+
+  @Override
+  public abstract String getParentSpanId();
 
   @Override
   public final boolean hasEnded() {
@@ -144,6 +148,14 @@ public abstract class TestSpanData implements SpanData {
      * @return this.
      */
     public abstract Builder setParentSpanId(String parentSpanId);
+
+    /**
+     * The parent SpanContext associated for this span, which may be null.
+     *
+     * @param parentSpanContext the SpanContext of the parent
+     * @return this.
+     */
+    public abstract Builder setParentSpanContext(SpanContext parentSpanContext);
 
     /**
      * Set the {@link Resource} associated with this span. Must not be null.


### PR DESCRIPTION
OpenTelemetry has API breaking changes from 0.11.0 onwards.  PR for updating Google Trace / Metrics to use OpenTelemetry 0.13.1