### PR TITLE
Update to use Nebula-Release plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ out/
 build/
 bin/
 
+# Mock server download
+mock_server*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,6 +43,9 @@ your OSSRH (OSS Repository Hosting) account and signing keys.
     checkstyle.ignoreFailures=false
     ```
 
+### Using GPG-Agent for artifact signing
+
+
 ## Download the mock server
 
 - Run the `get_mock_server.sh` script, which downloads the [mock server
@@ -52,6 +55,15 @@ your OSSRH (OSS Repository Hosting) account and signing keys.
     ```bash
     $ source ./get_mock_server.sh
     ```
+
+## Release a Snapshot
+
+If you've followed the above steps, you can release snapshots for consumption using the following:
+
+```bash
+$ ./gradlew snapshot -Dmock.server.path=$MOCKSERVER
+```
+
 
 ## Tagging the Release
 

--- a/build.gradle
+++ b/build.gradle
@@ -144,20 +144,6 @@ subprojects {
         archives javadocJar, sourcesJar
     }
 
-    signing {
-        required false
-        // Allow using the GPG agent on linux instead of passwords in a .properties file.
-        if (rootProject.hasProperty('signingUseGpgCmd')) {
-          useGpgCmd()
-        }
-        //sign publishing.publications.mavenJava
-        afterEvaluate {
-            if (publishing.publications.findByName('mavenJava') != null) {
-                sign publishing.publications.mavenJava
-            }
-        }
-    }
-
     javadoc {
         if(JavaVersion.current().isJava9Compatible()) {
             options.addBooleanOption('html5', true)
@@ -210,15 +196,25 @@ subprojects {
                         description = project.description	
                     }
                 }
-                repositories {
-                    maven {
-                        // change URLs to point to your repos, e.g. http://my.org/repo
-                        def releasesRepoUrl = "$buildDir/repos/releases"
-                        def snapshotsRepoUrl = "$buildDir/repos/snapshots"
-                        url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-                    }
-                }
             }
         }
+        repositories {
+            // For testing pruposes, we release locally.
+            maven {
+                // change URLs to point to your repos, e.g. http://my.org/repo
+                def releasesRepoUrl = "$buildDir/repos/releases"
+                def snapshotsRepoUrl = "$buildDir/repos/snapshots"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            }
+        }
+    }
+
+    signing {
+        required false
+        // Allow using the GPG agent on linux instead of passwords in a .properties file.
+        if (rootProject.hasProperty('signingUseGpgCmd')) {
+          useGpgCmd()
+        }
+        sign publishing.publications.maven
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,10 @@ subprojects {
         withJavadocJar()
         withSourcesJar()
     }
+    
+    releaseTask.configure {	
+      finalizedBy(tasks.named('publish'))
+    }
 
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ if (file('.git').exists()) {
     releaseTask = tasks.register('release')
 }
 
+ext.isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
+
 subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java-library'
@@ -203,7 +205,7 @@ subprojects {
                 def ossrhSnapshot = "https://oss.sonatype.org/content/repositories/snapshots/"
                 url = isReleaseVersion ? ossrhRelease : ossrhSnapshot
                 credentials {
-                    username = rootProject.hasProperty.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : "Unknown user"
+                    username = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : "Unknown user"
                     password = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : "Unknown password"
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'nebula.nebula-release'
     group = "com.google.cloud.opentelemetry"
-    version = "0.13.1-SNAPSHOT" // CURRENT_VERSION
+    version = "0.14.0-SNAPSHOT" // CURRENT_VERSION
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java-library'
     apply plugin: 'maven'
+    apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'nebula.nebula-release'
@@ -64,6 +65,9 @@ subprojects {
     plugins.withId("java") {
         plugins.apply('checkstyle')
         plugins.apply('com.diffplug.spotless')
+
+        // Configure our default module name for maven publishing
+        archivesBaseName = "${project.name}"
     }
 
     // Include license check and auto-format support.
@@ -146,51 +150,72 @@ subprojects {
         if (rootProject.hasProperty('signingUseGpgCmd')) {
           useGpgCmd()
         }
-        sign configurations.archives
+        //sign publishing.publications.mavenJava
+        afterEvaluate {
+            if (publishing.publications.findByName('mavenJava') != null) {
+                sign publishing.publications.mavenJava
+            }
+        }
     }
 
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+    javadoc {
+        if(JavaVersion.current().isJava9Compatible()) {
+            options.addBooleanOption('html5', true)
+        }
+    }
 
-                def configureAuth = {
-                    if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-                        authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
-                    }
+    java {
+        withJavadocJar()
+        withSourcesJar()
+    }
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                from components.java
+                groupId = 'com.google.cloud.opentelemetry'
+                afterEvaluate {
+                  artifactId = archivesBaseName
                 }
-
-                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/", configureAuth)
-
-                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/", configureAuth)
-
-                pom.project {
-                    name 'OpenTelemetry Operations Java'
-                    description 'OpenTelemetry exporters to Google Cloud Trace and Google Cloud Monitoring'
-                    packaging 'jar'
-                    url 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-
-                    scm {
-                        connection 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-                        developerConnection 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-                        url 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-                    }
-
+                versionMapping {	
+                    allVariants {	
+                        fromResolutionResult()	
+                    }	
+                }
+                pom {
+                    name = 'OpenTelemetry Operations Java'
+                    url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
                     licenses {
                         license {
-                            name 'The Apache License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
                     }
-
                     developers {
                         developer {
-                            id 'com.google.cloud.opentelemetry'
-                            name 'OpenTelemetry Operations Contributors'
-                            email 'opentelemetry-team@google.com'
+                            id = 'com.google.cloud.opentelemetry'
+                            name = 'OpenTelemetry Operations Contributors'
+                            email = 'opentelemetry-team@google.com'
                             organization = 'Google Inc'
-                            organizationUrl 'https://cloud.google.com/products/operations'
+                            organizationUrl = 'https://cloud.google.com/products/operations'
                         }
+                    }
+                    scm {
+                        connection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+                        developerConnection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+                        url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+                    }
+                    afterEvaluate {	
+                        // description is not available until evaluated.	
+                        description = project.description	
+                    }
+                }
+                repositories {
+                    maven {
+                        // change URLs to point to your repos, e.g. http://my.org/repo
+                        def releasesRepoUrl = "$buildDir/repos/releases"
+                        def snapshotsRepoUrl = "$buildDir/repos/snapshots"
+                        url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ subprojects {
 
     // Set up java codestyle checking and correction.
     plugins.withId("java") {
-        plugins.apply('checkstyle')
         plugins.apply('com.diffplug.spotless')
 
         // Configure our default module name for maven publishing
@@ -199,12 +198,14 @@ subprojects {
             }
         }
         repositories {
-            // For testing pruposes, we release locally.
             maven {
-                // change URLs to point to your repos, e.g. http://my.org/repo
-                def releasesRepoUrl = "$buildDir/repos/releases"
-                def snapshotsRepoUrl = "$buildDir/repos/snapshots"
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                def ossrhRelease = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def ossrhSnapshot = "https://oss.sonatype.org/content/repositories/snapshots/"
+                url = isReleaseVersion ? ossrhRelease : ossrhSnapshot
+                credentials {
+                    username = rootProject.hasProperty.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : "Unknown user"
+                    password = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : "Unknown password"
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,39 @@
  * limitations under the License.
  */
 
+import nebula.plugin.release.git.opinion.Strategies
 plugins {
     id "com.diffplug.spotless"
+    id 'nebula.release'
 }
+
+// Configure release mechanism.
+// Nebula plugin will not configure if .git doesn't exist, let's allow building on it by stubbing it
+// out. This supports building from the zip archive downloaded from GitHub.
+def releaseTask
+if (file('.git').exists()) {
+    release {
+        defaultVersionStrategy = Strategies.getSNAPSHOT()
+    }
+    nebulaRelease {
+        addReleaseBranchPattern(/v\d+\.\d+\.x/)
+    }
+
+    releaseTask = tasks.named("release")
+    releaseTask.configure {
+        mustRunAfter("snapshotSetup", "finalSetup")
+    }
+} else {
+    releaseTask = tasks.register('release')
+}
+
 subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java-library'
     apply plugin: 'maven'
     apply plugin: 'signing'
     apply plugin: 'com.diffplug.spotless'
-
+    apply plugin: 'nebula.nebula-release'
     group = "com.google.cloud.opentelemetry"
     version = "0.13.1-SNAPSHOT" // CURRENT_VERSION
 

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "com.github.johnrengelman.shadow" version "6.0.0"
+    id "com.github.johnrengelman.shadow"
 }
 
 description = 'Auto Exporter for OpenTelemetry'

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategy.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategy.java
@@ -26,7 +26,7 @@ public interface MetricDescriptorStrategy {
    * Determines what to do with metrci descriptors.
    *
    * @param batchDescriptors The set of metrics being exported in a batch.
-   * @param client A consumer that will ensure metric descriptors are registered to cloud
+   * @param export A consumer that will ensure metric descriptors are registered to cloud
    *     monitoring.
    */
   void exportDescriptors(

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -45,8 +45,8 @@ import java.util.function.BiConsumer;
 class TraceTranslator {
 
   // TODO(nilebox): Extract the constant
-  private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.6.0";
-  private static final String EXPORTER_VERSION = "0.1.0";
+  private static final String OPEN_TELEMETRY_LIBRARY_VERSION = "0.14.1";
+  private static final String EXPORTER_VERSION = "0.14.0";
   private static final String AGENT_LABEL_KEY = "g.co/agent";
   private static final String AGENT_LABEL_VALUE_STRING =
       "opentelemetry-java "

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -147,7 +147,7 @@ public class TraceTranslatorTest {
     assertTrue(translatedAttributes.containsAttributeMap("g.co/agent"));
     assertEquals(
         translatedAttributes.getAttributeMapMap().get("g.co/agent").getStringValue().getValue(),
-        "opentelemetry-java 0.6.0; google-cloud-trace-exporter 0.1.0");
+        "opentelemetry-java 0.14.1; google-cloud-trace-exporter 0.14.0");
   }
 
   @Test
@@ -191,7 +191,7 @@ public class TraceTranslatorTest {
     Map<String, AttributeValue> attributeMap = attributes.getAttributeMapMap();
     assertEquals("value", attributeMap.get("key").getStringValue().getValue());
     assertEquals(
-        "opentelemetry-java 0.6.0; google-cloud-trace-exporter 0.1.0",
+        "opentelemetry-java 0.14.1; google-cloud-trace-exporter 0.14.0",
         attributeMap.get("g.co/agent").getStringValue().getValue());
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@
 pluginManagement {
     plugins {
         id "com.diffplug.spotless" version "5.9.0"
+        id 'nebula.release' version '15.2.0'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ pluginManagement {
     plugins {
         id "com.diffplug.spotless" version "5.9.0"
         id 'nebula.release' version '15.2.0'
+        id "com.github.johnrengelman.shadow" version "6.0.0"
     }
 }
 


### PR DESCRIPTION
This should dramatically improve our release instructions (in the near term) to just: 

`./gradlew {snapshot}` for snapshot builds and
`./gradlew -Prelease.veresion={version}` for release

Note: The release plugin will autoamtically create local git tags for you.

Long term, this should also be usable for a completed GHA-based publishing mechanism as used by OTel Java.

TL;DR; on Changes

- Leverage settings.gradle for plugin versioning in one location
- Add Nebula Release plugin to buld
- Move from deprecated `uploadArtifacts` task to `publish`
- Various gradle build jiggery-pokery
- Update all version strings to reflect the 0.14 java usage + prep for a 0.14.0 release of the exporters.