### PR TITLE
Allow artifacts to opt-in to release or not.  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,68 +179,75 @@ subprojects {
 		finalizedBy(tasks.named('publish'))
 	}
 
-	publishing {
-		publications {
-			maven(MavenPublication) {
-				from components.java
-				groupId = 'com.google.cloud.opentelemetry'
-				afterEvaluate {
-					artifactId = archivesBaseName
-				}
-				versionMapping {
-					allVariants {
-						fromResolutionResult()
-					}
-				}
-				pom {
-					name = 'OpenTelemetry Operations Java'
-					url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-					licenses {
-						license {
-							name = 'The Apache License, Version 2.0'
-							url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-						}
-					}
-					developers {
-						developer {
-							id = 'com.google.cloud.opentelemetry'
-							name = 'OpenTelemetry Operations Contributors'
-							email = 'opentelemetry-team@google.com'
-							organization = 'Google Inc'
-							organizationUrl = 'https://cloud.google.com/products/operations'
-						}
-					}
-					scm {
-						connection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-						developerConnection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-						url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
-					}
+	if (findProperty("release.enabled") == "true") {
+		publishing {
+			publications {
+				maven(MavenPublication) {
+					from components.java
+					groupId = 'com.google.cloud.opentelemetry'
 					afterEvaluate {
-						// description is not available until evaluated.
-						description = project.description
+						artifactId = archivesBaseName
+						if (findProperty("release.qualifier") != null) {
+							String[] versionParts = version.split('-')
+							versionParts[0] = "${versionParts[0]}-${findProperty("release.qualifier")}"
+							version = versionParts.join("-")
+						}
+					}
+					versionMapping {
+						allVariants {
+							fromResolutionResult()
+						}
+					}
+					pom {
+						name = 'OpenTelemetry Operations Java'
+						url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+						licenses {
+							license {
+								name = 'The Apache License, Version 2.0'
+								url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+							}
+						}
+						developers {
+							developer {
+								id = 'com.google.cloud.opentelemetry'
+								name = 'OpenTelemetry Operations Contributors'
+								email = 'opentelemetry-team@google.com'
+								organization = 'Google Inc'
+								organizationUrl = 'https://cloud.google.com/products/operations'
+							}
+						}
+						scm {
+							connection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+							developerConnection = 'scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+							url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'
+						}
+						afterEvaluate {
+							// description is not available until evaluated.
+							description = project.description
+						}
+					}
+				}
+			}
+			repositories {
+				maven {
+					def ossrhRelease = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+					def ossrhSnapshot = "https://oss.sonatype.org/content/repositories/snapshots/"
+					url = isReleaseVersion ? ossrhRelease : ossrhSnapshot
+					credentials {
+						username = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : "Unknown user"
+						password = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : "Unknown password"
 					}
 				}
 			}
 		}
-		repositories {
-			maven {
-				def ossrhRelease = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-				def ossrhSnapshot = "https://oss.sonatype.org/content/repositories/snapshots/"
-				url = isReleaseVersion ? ossrhRelease : ossrhSnapshot
-				credentials {
-					username = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : "Unknown user"
-					password = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : "Unknown password"
-				}
-			}
-		}
-	}
 
-	signing {
-		required false
-		// Allow using the GPG agent on linux instead of passwords in a .properties file.
-		if (rootProject.hasProperty('signingUseGpgCmd')) {
-			useGpgCmd()
+		signing {
+			required false
+			// Allow using the GPG agent on linux instead of passwords in a .properties file.
+			if (rootProject.hasProperty('signingUseGpgCmd')) {
+				useGpgCmd()
+			}
+			sign publishing.publications.maven
 		}
-		sign publishing.publications.maven
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ subprojects {
 	// Make sure test failures include exception error messages for correction.
 	test {
 		testLogging {
+			events "passed", "skipped", "failed", "standardOut", "standardError"
 			exceptionFormat = 'full'
 		}
 	}

--- a/detectors/resources/gradle.properties
+++ b/detectors/resources/gradle.properties
@@ -1,0 +1,2 @@
+release.qualifier=alpha
+release.enabled=false

--- a/exporters/auto/gradle.properties
+++ b/exporters/auto/gradle.properties
@@ -1,0 +1,2 @@
+release.qualifier=alpha
+release.enabled=true

--- a/exporters/metrics/gradle.properties
+++ b/exporters/metrics/gradle.properties
@@ -1,0 +1,2 @@
+release.qualifier=alpha
+release.enabled=true

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
@@ -45,7 +45,7 @@ public class EndToEndTest {
               .withDockerfileFromBuilder(
                   builder ->
                       builder
-                          .from("golang")
+                          .from("golang:1.15")
                           .run("go get github.com/googleinterns/cloud-operations-api-mock/cmd")
                           .cmd(
                               "go run github.com/googleinterns/cloud-operations-api-mock/cmd --address=:8080")

--- a/exporters/trace/gradle.properties
+++ b/exporters/trace/gradle.properties
@@ -1,0 +1,1 @@
+release.enabled=true

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -67,7 +67,7 @@ public class EndToEndTest {
               .withDockerfileFromBuilder(
                   builder ->
                       builder
-                          .from("golang")
+                          .from("golang:1.15")
                           .run("go get github.com/googleinterns/cloud-operations-api-mock/cmd")
                           .cmd(
                               "go run github.com/googleinterns/cloud-operations-api-mock/cmd --address=:8080")


### PR DESCRIPTION
- Add new mechanism to the build to look for `gradle.properties` file to determine publishing (as done in otel-java)
- Remove examples from publishing JARs onto maven central
- Mark Metrics + Auto instrumentation 'alpha' in accordance with community status.
- Mark Resource detection as not published (for now)

Output from my `publishToMavenLocal`:

```
$ ls ~/.m2/repository/com/google/cloud/opentelemetry/*
/home/joshuasuereth/.m2/repository/com/google/cloud/opentelemetry/exporter-auto:
0.14.0-alpha-SNAPSHOT  maven-metadata-local.xml

/home/joshuasuereth/.m2/repository/com/google/cloud/opentelemetry/exporter-metrics:
0.14.0-alpha-SNAPSHOT  maven-metadata-local.xml

/home/joshuasuereth/.m2/repository/com/google/cloud/opentelemetry/exporter-trace:
0.14.0-SNAPSHOT  maven-metadata-local.xml
```