### PR TITLE
Bump all version to 1.0/1.0-alpha releases and update APIs/examples f…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,8 @@ subprojects {
 		slf4jVersion = '1.7.30'
 		googleCloudVersion = '1.0.2'
 		cloudMonitoringVersion = '2.0.1'
-		openTelemetryVersion = '0.14.1'
-		openTelemetryInstrumentationVersion = '0.14.0'
+		openTelemetryVersion = '1.0.0'
+		openTelemetryInstrumentationVersion = '0.17.0'
 		junitVersion = '4.13'
 		mockitoVersion = '3.5.10'
 		testContainersVersion = '1.15.1'
@@ -127,10 +127,11 @@ subprojects {
 			slf4j                        : "org.slf4j:slf4j-api:${slf4jVersion}",
 			opentelemetry_api            : "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
 			opentelemetry_sdk            : "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
-			opentelemetry_semconv        : "io.opentelemetry:opentelemetry-semconv:${openTelemetryVersion}",
+			opentelemetry_autoconfigure  : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}-alpha",
+			opentelemetry_semconv        : "io.opentelemetry:opentelemetry-semconv:${openTelemetryVersion}-alpha",
 			opentelemetry_api_metrics    : "io.opentelemetry:opentelemetry-api-metrics:${openTelemetryVersion}-alpha",
 			opentelemetry_sdk_metrics    : "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}-alpha",
-			opentelemetry_auto           : "io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${openTelemetryInstrumentationVersion}",
+			opentelemetry_auto           : "io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${openTelemetryInstrumentationVersion}-alpha",
 		]
 		testLibraries = [
 			junit       : "junit:junit:${junitVersion}",

--- a/detectors/resources/build.gradle
+++ b/detectors/resources/build.gradle
@@ -18,6 +18,8 @@ description = 'Google Cloud resource provider for OpenTelemetry'
 dependencies {
 	implementation(libraries.opentelemetry_api)
 	implementation(libraries.opentelemetry_sdk)
+	implementation(libraries.opentelemetry_autoconfigure)
+	implementation(libraries.opentelemetry_semconv)
 	testImplementation(testLibraries.junit)
 	testImplementation(testLibraries.wiremock)
 }

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCEResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCEResourceTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,13 +72,13 @@ public class GCEResourceTest {
     Map<AttributeKey<String>, String> expectedAttributes =
         Stream.of(
                 new Object[][] {
-                  {SemanticAttributes.CLOUD_PROVIDER, SemanticAttributes.CloudProviderValues.GCP},
-                  {SemanticAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
-                  {SemanticAttributes.CLOUD_ZONE, "country-region-zone"},
-                  {SemanticAttributes.CLOUD_REGION, "country-region"},
-                  {SemanticAttributes.HOST_ID, "GCE-instance-id"},
-                  {SemanticAttributes.HOST_NAME, "GCE-instance-name"},
-                  {SemanticAttributes.HOST_TYPE, "GCE-instance-type"}
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"}
                 })
             .collect(
                 Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GKEResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GKEResourceTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -82,17 +82,17 @@ public class GKEResourceTest {
     Map<AttributeKey<String>, String> expectedAttributes =
         Stream.of(
                 new Object[][] {
-                  {SemanticAttributes.CLOUD_PROVIDER, "gcp"},
-                  {SemanticAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
-                  {SemanticAttributes.CLOUD_ZONE, "country-region-zone"},
-                  {SemanticAttributes.CLOUD_REGION, "country-region"},
-                  {SemanticAttributes.HOST_ID, "GCE-instance-id"},
-                  {SemanticAttributes.HOST_NAME, "GCE-instance-name"},
-                  {SemanticAttributes.HOST_TYPE, "GCE-instance-type"},
-                  {SemanticAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"},
-                  {SemanticAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"},
-                  {SemanticAttributes.K8S_POD_NAME, "GKE-testHostName"},
-                  {SemanticAttributes.K8S_CONTAINER_NAME, "GKE-testContainerName"}
+                  {ResourceAttributes.CLOUD_PROVIDER, "gcp"},
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"},
+                  {ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"},
+                  {ResourceAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"},
+                  {ResourceAttributes.K8S_POD_NAME, "GKE-testHostName"},
+                  {ResourceAttributes.K8S_CONTAINER_NAME, "GKE-testContainerName"}
                 })
             .collect(
                 Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -42,11 +42,12 @@ public class TraceExporterExample {
     try {
       TraceExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
       // Register the TraceExporter with OpenTelemetry
-      return OpenTelemetrySdk.builder().setTracerProvider(
-        SdkTracerProvider.builder()
-          .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build())
-          .build())
-        .buildAndRegisterGlobal();
+      return OpenTelemetrySdk.builder()
+          .setTracerProvider(
+              SdkTracerProvider.builder()
+                  .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build())
+                  .build())
+          .buildAndRegisterGlobal();
     } catch (IOException e) {
       System.out.println("Uncaught Exception");
       return null;

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -24,9 +24,9 @@ import com.google.api.MetricDescriptor;
 import com.google.cloud.opentelemetry.metric.MetricExporter.MetricWithLabels;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.monitoring.v3.TypedValue;
-import io.opentelemetry.api.common.Labels;
-import io.opentelemetry.sdk.metrics.data.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.LongPoint;
+import io.opentelemetry.api.metrics.common.Labels;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,7 +45,7 @@ public class AggregateByLabelMetricTimeSeriesBuilder implements MetricTimeSeries
   }
 
   @Override
-  public void recordPoint(MetricData metric, LongPoint point) {
+  public void recordPoint(MetricData metric, LongPointData point) {
     MetricDescriptor descriptor = mapMetricDescriptor(metric, point);
     if (descriptor == null) {
       return;
@@ -64,7 +64,7 @@ public class AggregateByLabelMetricTimeSeriesBuilder implements MetricTimeSeries
   }
 
   @Override
-  public void recordPoint(MetricData metric, DoublePoint point) {
+  public void recordPoint(MetricData metric, DoublePointData point) {
     MetricDescriptor descriptor = mapMetricDescriptor(metric, point);
     if (descriptor == null) {
       return;

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricExporter.java
@@ -29,18 +29,16 @@ import com.google.common.collect.Lists;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.ProjectName;
 import com.google.monitoring.v3.TimeSeries;
-import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.metrics.data.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.LongPoint;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,14 +48,11 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
   private static final Logger logger = LoggerFactory.getLogger(MetricExporter.class);
 
   private static final String PROJECT_NAME_PREFIX = "projects/";
-  private static final long WRITE_INTERVAL_SECOND = 12;
   private static final int MAX_BATCH_SIZE = 200;
-  private static final long NANO_PER_SECOND = (long) 1e9;
 
   private final CloudMetricClient metricServiceClient;
   private final String projectId;
   private final MetricDescriptorStrategy metricDescriptorStrategy;
-  private final Map<MetricWithLabels, Long> lastUpdatedTime = new HashMap<>();
 
   MetricExporter(
       String projectId, CloudMetricClient client, MetricDescriptorStrategy descriptorStrategy) {
@@ -141,22 +136,22 @@ public class MetricExporter implements io.opentelemetry.sdk.metrics.export.Metri
       // Extract all the underlying points.
       switch (metricData.getType()) {
         case LONG_GAUGE:
-          for (LongPoint point : metricData.getLongGaugeData().getPoints()) {
+          for (LongPointData point : metricData.getLongGaugeData().getPoints()) {
             builder.recordPoint(metricData, point);
           }
           break;
         case LONG_SUM:
-          for (LongPoint point : metricData.getLongSumData().getPoints()) {
+          for (LongPointData point : metricData.getLongSumData().getPoints()) {
             builder.recordPoint(metricData, point);
           }
           break;
         case DOUBLE_GAUGE:
-          for (DoublePoint point : metricData.getDoubleGaugeData().getPoints()) {
+          for (DoublePointData point : metricData.getDoubleGaugeData().getPoints()) {
             builder.recordPoint(metricData, point);
           }
           break;
         case DOUBLE_SUM:
-          for (DoublePoint point : metricData.getDoubleSumData().getPoints()) {
+          for (DoublePointData point : metricData.getDoubleSumData().getPoints()) {
             builder.recordPoint(metricData, point);
           }
           break;

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTimeSeriesBuilder.java
@@ -17,8 +17,8 @@ package com.google.cloud.opentelemetry.metric;
 
 import com.google.api.MetricDescriptor;
 import com.google.monitoring.v3.TimeSeries;
-import io.opentelemetry.sdk.metrics.data.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.LongPoint;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
 import java.util.List;
@@ -26,9 +26,9 @@ import java.util.List;
 /** An interface that denotes how we build our API calls from metric data. */
 public interface MetricTimeSeriesBuilder {
   /** Records a LongPoint of the given metric. */
-  void recordPoint(MetricData metric, LongPoint point);
+  void recordPoint(MetricData metric, LongPointData point);
   /** Records a DoublePoint of the given metric. */
-  void recordPoint(MetricData metric, DoublePoint point);
+  void recordPoint(MetricData metric, DoublePointData point);
 
   /** The set of descriptors assocaited with the current time series. */
   Collection<MetricDescriptor> getDescriptors();

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
@@ -30,11 +30,11 @@ import com.google.monitoring.v3.TimeInterval;
 import com.google.protobuf.Timestamp;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -65,9 +65,9 @@ public class MetricTranslator {
   private static final Map<String, AttributeKey<String>> gceMap =
       Stream.of(
               new Object[][] {
-                {"project_id", SemanticAttributes.CLOUD_ACCOUNT_ID},
-                {"instance_id", SemanticAttributes.HOST_ID},
-                {"zone", SemanticAttributes.CLOUD_ZONE}
+                {"project_id", ResourceAttributes.CLOUD_ACCOUNT_ID},
+                {"instance_id", ResourceAttributes.HOST_ID},
+                {"zone", ResourceAttributes.CLOUD_ZONE}
               })
           .collect(
               Collectors.toMap(data -> (String) data[0], data -> (AttributeKey<String>) data[1]));
@@ -76,13 +76,13 @@ public class MetricTranslator {
   private static final Map<String, AttributeKey<String>> gkeMap =
       Stream.of(
               new Object[][] {
-                {"project_id", SemanticAttributes.CLOUD_ACCOUNT_ID},
-                {"cluster_name", SemanticAttributes.K8S_CLUSTER_NAME},
-                {"namespace_id", SemanticAttributes.K8S_NAMESPACE_NAME},
-                {"instance_id", SemanticAttributes.HOST_ID},
-                {"pod_id", SemanticAttributes.K8S_POD_NAME},
-                {"container_name", SemanticAttributes.K8S_CONTAINER_NAME},
-                {"zone", SemanticAttributes.CLOUD_ZONE}
+                {"project_id", ResourceAttributes.CLOUD_ACCOUNT_ID},
+                {"cluster_name", ResourceAttributes.K8S_CLUSTER_NAME},
+                {"namespace_id", ResourceAttributes.K8S_NAMESPACE_NAME},
+                {"instance_id", ResourceAttributes.HOST_ID},
+                {"pod_id", ResourceAttributes.K8S_POD_NAME},
+                {"container_name", ResourceAttributes.K8S_CONTAINER_NAME},
+                {"zone", ResourceAttributes.CLOUD_ZONE}
               })
           .collect(
               Collectors.toMap(data -> (String) data[0], data -> (AttributeKey<String>) data[1]));
@@ -94,7 +94,7 @@ public class MetricTranslator {
   }
 
   static MetricDescriptor mapMetricDescriptor(
-      MetricData metric, io.opentelemetry.sdk.metrics.data.Point metricPoint) {
+      MetricData metric, io.opentelemetry.sdk.metrics.data.PointData metricPoint) {
     MetricDescriptor.Builder builder =
         MetricDescriptor.newBuilder()
             .setDisplayName(metric.getName())
@@ -148,7 +148,7 @@ public class MetricTranslator {
   }
 
   static TimeInterval mapInterval(
-      io.opentelemetry.sdk.metrics.data.Point point, MetricDataType metricType) {
+      io.opentelemetry.sdk.metrics.data.PointData point, MetricDataType metricType) {
     Timestamp startTime = mapTimestamp(point.getStartEpochNanos());
     Timestamp endTime = mapTimestamp(point.getEpochNanos());
     if (GAUGE_TYPES.contains(metricType)) {
@@ -173,9 +173,9 @@ public class MetricTranslator {
     Attributes attributes = resource.getAttributes();
 
     // GCE: https://cloud.google.com/monitoring/api/resources#tag_gce_instance
-    String provider = attributes.get(SemanticAttributes.CLOUD_PROVIDER);
-    if (SemanticAttributes.CloudProviderValues.GCP.equals(provider)) {
-      String namespace = attributes.get(SemanticAttributes.K8S_NAMESPACE_NAME);
+    String provider = attributes.get(ResourceAttributes.CLOUD_PROVIDER);
+    if (ResourceAttributes.CloudProviderValues.GCP.equals(provider)) {
+      String namespace = attributes.get(ResourceAttributes.K8S_NAMESPACE_NAME);
       if (namespace != null) {
         return MonitoredResource.newBuilder()
             .setType("gke_container")

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -20,12 +20,12 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.DoubleSummaryPoint;
-import io.opentelemetry.sdk.metrics.data.LongPoint;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.DoubleSummaryPointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.LongSumData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
@@ -61,22 +61,22 @@ public class FakeData {
   static final InstrumentationLibraryInfo anInstrumentationLibraryInfo =
       InstrumentationLibraryInfo.create("instrumentName", "0");
 
-  static final LongPoint aLongPoint =
-      LongPoint.create(
+  static final LongPointData aLongPoint =
+      LongPointData.create(
           1599030114 * NANO_PER_SECOND,
           1599031814 * NANO_PER_SECOND,
           Labels.of("label1", "value1", "label2", "False"),
           32L);
 
-  static final DoublePoint aDoublePoint =
-      DoublePoint.create(
+  static final DoublePointData aDoublePoint =
+      DoublePointData.create(
           1599030114 * NANO_PER_SECOND,
           1599031814 * NANO_PER_SECOND,
           Labels.of("label1", "value1", "label2", "False"),
           32d);
 
-  static final DoubleSummaryPoint aDoubleSummaryPoint =
-      DoubleSummaryPoint.create(
+  static final DoubleSummaryPointData aDoubleSummaryPoint =
+      DoubleSummaryPointData.create(
           1599030114 * NANO_PER_SECOND,
           1599031814 * NANO_PER_SECOND,
           Labels.of("label1", "value1", "label2", "False"),

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -52,7 +52,6 @@ import com.google.monitoring.v3.TypedValue;
 import com.google.protobuf.Timestamp;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.DoubleSummaryData;
-import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -52,7 +52,7 @@ import com.google.monitoring.v3.TypedValue;
 import com.google.protobuf.Timestamp;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.DoubleSummaryData;
-import io.opentelemetry.sdk.metrics.data.LongPoint;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -126,7 +126,7 @@ public class MetricExporterTest {
             .build();
     Point expectedPoint =
         Point.newBuilder()
-            .setValue(TypedValue.newBuilder().setInt64Value(((LongPoint) aLongPoint).getValue()))
+            .setValue(TypedValue.newBuilder().setInt64Value(aLongPoint.getValue()))
             .setInterval(expectedTimeInterval)
             .build();
     TimeSeries expectedTimeSeries =

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
@@ -39,7 +39,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.metrics.data.DoubleSummaryData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -130,13 +130,13 @@ public class MetricTranslatorTest {
     Map<AttributeKey<String>, String> testAttributes =
         Stream.of(
                 new Object[][] {
-                  {SemanticAttributes.CLOUD_PROVIDER, SemanticAttributes.CloudProviderValues.GCP},
-                  {SemanticAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
-                  {SemanticAttributes.CLOUD_ZONE, "country-region-zone"},
-                  {SemanticAttributes.CLOUD_REGION, "country-region"},
-                  {SemanticAttributes.HOST_ID, "GCE-instance-id"},
-                  {SemanticAttributes.HOST_NAME, "GCE-instance-name"},
-                  {SemanticAttributes.HOST_TYPE, "GCE-instance-type"}
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"}
                 })
             .collect(
                 Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
@@ -174,17 +174,17 @@ public class MetricTranslatorTest {
     Map<AttributeKey<String>, String> testAttributes =
         Stream.of(
                 new Object[][] {
-                  {SemanticAttributes.CLOUD_PROVIDER, SemanticAttributes.CloudProviderValues.GCP},
-                  {SemanticAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
-                  {SemanticAttributes.CLOUD_ZONE, "country-region-zone"},
-                  {SemanticAttributes.CLOUD_REGION, "country-region"},
-                  {SemanticAttributes.HOST_ID, "GCE-instance-id"},
-                  {SemanticAttributes.HOST_NAME, "GCE-instance-name"},
-                  {SemanticAttributes.HOST_TYPE, "GCE-instance-type"},
-                  {SemanticAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"},
-                  {SemanticAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"},
-                  {SemanticAttributes.K8S_POD_NAME, "GKE-testHostName"},
-                  {SemanticAttributes.K8S_CONTAINER_NAME, "GKE-testContainerName"}
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"},
+                  {ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"},
+                  {ResourceAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"},
+                  {ResourceAttributes.K8S_POD_NAME, "GKE-testHostName"},
+                  {ResourceAttributes.K8S_CONTAINER_NAME, "GKE-testContainerName"}
                 })
             .collect(
                 Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -29,7 +29,7 @@ import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.protobuf.BoolValue;
 import com.google.rpc.Status;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.LinkData;
@@ -100,12 +100,12 @@ class TraceTranslator {
   }
 
   @VisibleForTesting
-  static String toDisplayName(String spanName, @javax.annotation.Nullable Kind spanKind) {
-    if (spanKind == Kind.SERVER && !spanName.startsWith(SERVER_PREFIX)) {
+  static String toDisplayName(String spanName, @javax.annotation.Nullable SpanKind spanKind) {
+    if (spanKind == SpanKind.SERVER && !spanName.startsWith(SERVER_PREFIX)) {
       return SERVER_PREFIX + spanName;
     }
 
-    if (spanKind == Kind.CLIENT && !spanName.startsWith(CLIENT_PREFIX)) {
+    if (spanKind == SpanKind.CLIENT && !spanName.startsWith(CLIENT_PREFIX)) {
       return CLIENT_PREFIX + spanName;
     }
 
@@ -240,8 +240,8 @@ class TraceTranslator {
   private static Link toLinkProto(LinkData link) {
     checkNotNull(link);
     return Link.newBuilder()
-        .setTraceId(link.getSpanContext().getTraceIdAsHexString())
-        .setSpanId(link.getSpanContext().getSpanIdAsHexString())
+        .setTraceId(link.getSpanContext().getTraceId())
+        .setSpanId(link.getSpanContext().getSpanId())
         .setType(Link.Type.TYPE_UNSPECIFIED)
         .setAttributes(toAttributesBuilderProto(link.getAttributes()))
         .build();

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.opentelemetry.trace;
 
-import static io.opentelemetry.api.trace.attributes.SemanticAttributes.TELEMETRY_SDK_VERSION;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.TELEMETRY_SDK_VERSION;
 // import static
 // io.opentelemetry.semconv.resource.attributes.ResourceAttributes.TELEMETRY_SDK_VERSION;
 
@@ -31,7 +31,7 @@ public class TraceVersions {
 
   @Nullable
   private static String readSdkVersion() {
-    return Resource.getTelemetrySdk().getAttributes().get(TELEMETRY_SDK_VERSION);
+    return Resource.getDefault().getAttributes().get(TELEMETRY_SDK_VERSION);
   }
 
   @Nullable

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -18,9 +18,9 @@ package com.google.cloud.opentelemetry.trace;
 import static org.junit.Assert.assertTrue;
 
 import com.google.devtools.cloudtrace.v2.AttributeValue;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
@@ -97,7 +97,9 @@ public class EndToEndTest {
             .setParentSpanContext(
                 SpanContext.createFromRemoteParent(
                     TRACE_ID, PARENT_SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
-            .setSpanContext(SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
+            .setSpanContext(
+                SpanContext.create(
+                    TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
             .setName(SPAN_NAME)
             .setKind(SpanKind.SERVER)
             .setEvents(Collections.emptyList())

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -18,7 +18,7 @@ package com.google.cloud.opentelemetry.trace;
 import static org.junit.Assert.assertTrue;
 
 import com.google.devtools.cloudtrace.v2.AttributeValue;
-import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -97,10 +97,9 @@ public class EndToEndTest {
             .setParentSpanContext(
                 SpanContext.createFromRemoteParent(
                     TRACE_ID, PARENT_SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
-            .setSpanId(SPAN_ID)
-            .setTraceId(TRACE_ID)
+            .setSpanContext(SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
             .setName(SPAN_NAME)
-            .setKind(Kind.SERVER)
+            .setKind(SpanKind.SERVER)
             .setEvents(Collections.emptyList())
             .setStatus(SPAN_DATA_STATUS)
             .setStartEpochNanos(START_EPOCH_NANOS)

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -24,7 +24,7 @@ import com.google.devtools.cloudtrace.v2.Span;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.rpc.Status;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
@@ -46,8 +46,8 @@ public class TraceTranslatorTest {
     String serverPrefixSpanName = "Recv. mySpanName";
     String clientPrefixSpanName = "Sent. mySpanName";
     String regularSpanName = "regularSpanName";
-    Kind serverSpanKind = Kind.SERVER;
-    Kind clientSpanKind = Kind.CLIENT;
+    SpanKind serverSpanKind = SpanKind.SERVER;
+    SpanKind clientSpanKind = SpanKind.CLIENT;
 
     assertEquals(
         serverPrefixSpanName, TraceTranslator.toDisplayName(serverPrefixSpanName, serverSpanKind));


### PR DESCRIPTION
…or latest churn.

- Semantic conventions broken out into `Resource`
- Resource in Java SDK is now funky regarding auto configure vs. default.  Will hold off on any spi.ResourceProvider releases until this is less likely to break
- Metric API rename shuffles
- Trace API rename shuffles
- a couple unstable libraries NOW include -alpha in the version
- Span ids + trace ids now always come from context (see SpandData class).