### PR TITLE
Fix #88 - Status code mapping and expanded tests.

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -27,6 +27,7 @@ import com.google.devtools.cloudtrace.v2.Span.Links;
 import com.google.devtools.cloudtrace.v2.SpanName;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.protobuf.BoolValue;
+import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
@@ -214,7 +215,7 @@ class TraceTranslator {
     final StatusCode statusCode = status.getStatusCode();
     switch (statusCode) {
       case OK:
-        statusBuilder.setCode(0);
+        statusBuilder.setCode(Code.OK.getNumber());
         break;
       case UNSET:
         // We do not specify a code in the UNSET case.
@@ -228,7 +229,7 @@ class TraceTranslator {
         break;
       default:
         // Handle new/unknown codes as unknown
-        statusBuilder.setCode(2);
+        statusBuilder.setCode(Code.UNKNOWN.getNumber());
         break;
     }
     return statusBuilder.build();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -25,6 +25,7 @@ import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.rpc.Status;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
@@ -205,6 +206,13 @@ public class TraceTranslatorTest {
 
     // The int representation is 0 for canonical code "OK".
     assertEquals(0, spanStatus.getCode());
+
+    Status failStatus = TraceTranslator.toStatusProto(StatusData.create(StatusCode.ERROR, "FAIL!"));
+    assertEquals(2, failStatus.getCode());
+    assertEquals("FAIL!", failStatus.getMessage());
+
+    Status unsetStatus = TraceTranslator.toStatusProto(StatusData.unset());
+    assertEquals("Unset status should not create protos", null, unsetStatus);
   }
 
   @Test

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.Span;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
+import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -205,10 +206,10 @@ public class TraceTranslatorTest {
     Status spanStatus = TraceTranslator.toStatusProto(StatusData.ok());
 
     // The int representation is 0 for canonical code "OK".
-    assertEquals(0, spanStatus.getCode());
+    assertEquals(Code.OK.getNumber(), spanStatus.getCode());
 
     Status failStatus = TraceTranslator.toStatusProto(StatusData.create(StatusCode.ERROR, "FAIL!"));
-    assertEquals(2, failStatus.getCode());
+    assertEquals(Code.UNKNOWN.getNumber(), failStatus.getCode());
     assertEquals("FAIL!", failStatus.getMessage());
 
     Status unsetStatus = TraceTranslator.toStatusProto(StatusData.unset());


### PR DESCRIPTION
- Update status code mapping to match internal specification for OTLP=>Cloud Trace
- Expand the tests for status code mapping to handle "non ok" statuses.