### PR TITLE
Re-add javadoc to auto jar.

### DIFF
--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -48,6 +48,7 @@ publishing {
 		maven(MavenPublication) { publication ->
 			from project.shadow.component(publication)
 			artifact sourcesJar
+			artifact javadocJar
 			components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
 				skip()
 			}


### PR DESCRIPTION
Another thing that was dropped with custom shadow configuration.

Good news is, I suspect this is the last thing to fully resolve cache-issues and dependnecy problems.  Going forward I'd like to avoid having to shade.... ever.