### PR TITLE
Update resource mapping

### DIFF
--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -19,7 +19,7 @@ import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapDistribu
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapInterval;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetric;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetricDescriptor;
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapResource;
+import static com.google.cloud.opentelemetry.metric.ResourceTranslator.mapResource;
 
 import com.google.api.MetricDescriptor;
 import com.google.cloud.opentelemetry.metric.MetricExporter.MetricWithLabels;
@@ -106,7 +106,7 @@ public class AggregateByLabelMetricTimeSeriesBuilder implements MetricTimeSeries
     return TimeSeries.newBuilder()
         .setMetric(mapMetric(attributes, descriptor.getType()))
         .setMetricKind(descriptor.getMetricKind())
-        .setResource(mapResource(metric.getResource(), projectId));
+        .setResource(mapResource(metric.getResource()));
   }
 
   @Override

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.metric;
+
+import com.google.api.MonitoredResource;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.List;
+import java.util.Optional;
+
+/** Translates from OpenTelemetry Resource into Google Cloud Monitoring's MonitoredResource. */
+public class ResourceTranslator {
+  private ResourceTranslator() {}
+
+  @com.google.auto.value.AutoValue
+  public abstract static class AttributeMapping {
+    /** The label name used in GCP's MonitoredResource. */
+    public abstract String getLabelName();
+    /** The list of OTEL keys that can be used for this resource label, in priority order. */
+    public abstract java.util.List<AttributeKey<?>> getOtelKeys();
+    /** A fallback value to set the resource. */
+    public abstract Optional<String> fallbackLiteral();
+
+    public void fill(Resource resource, MonitoredResource.Builder builder) {
+      for (AttributeKey<?> key : getOtelKeys()) {
+        Object value = resource.getAttribute(key);
+        if (value != null) {
+          builder.putLabels(getLabelName(), value.toString());
+          return;
+        }
+      }
+      fallbackLiteral().ifPresent(value -> builder.putLabels(getLabelName(), value));
+    }
+
+    public static AttributeMapping create(String labelName, AttributeKey<?> otelKey) {
+      return new AutoValue_ResourceTranslator_AttributeMapping(
+          labelName, java.util.Collections.singletonList(otelKey), Optional.empty());
+    }
+
+    public static AttributeMapping create(
+        String labelName, java.util.List<AttributeKey<?>> otelKeys) {
+      return new AutoValue_ResourceTranslator_AttributeMapping(
+          labelName, otelKeys, Optional.empty());
+    }
+
+    public static AttributeMapping create(
+        String labelName, java.util.List<AttributeKey<?>> otelKeys, String fallbackLiteral) {
+      return new AutoValue_ResourceTranslator_AttributeMapping(
+          labelName, otelKeys, Optional.of(fallbackLiteral));
+    }
+  }
+
+  private static List<AttributeMapping> GCE_INSTANCE_LABELS =
+      java.util.Arrays.asList(
+          AttributeMapping.create("zone", ResourceAttributes.CLOUD_AVAILABILITY_ZONE),
+          AttributeMapping.create("instance_id", ResourceAttributes.HOST_ID));
+  private static List<AttributeMapping> K8S_POD_LABELS =
+      java.util.Arrays.asList(
+          AttributeMapping.create("location", ResourceAttributes.CLOUD_AVAILABILITY_ZONE),
+          AttributeMapping.create("cluster_name", ResourceAttributes.K8S_CLUSTER_NAME),
+          AttributeMapping.create("namespace_name", ResourceAttributes.K8S_NAMESPACE_NAME),
+          AttributeMapping.create("pod_name", ResourceAttributes.K8S_POD_NAME));
+  private static List<AttributeMapping> AWS_EC2_INSTANCE_LABELS =
+      java.util.Arrays.asList(
+          AttributeMapping.create("instance_id", ResourceAttributes.HOST_ID),
+          AttributeMapping.create("region", ResourceAttributes.CLOUD_AVAILABILITY_ZONE),
+          AttributeMapping.create("aws_account", ResourceAttributes.CLOUD_ACCOUNT_ID));
+  private static List<AttributeMapping> GENERIC_TASK_LABELS =
+      java.util.Arrays.asList(
+          AttributeMapping.create(
+              "location",
+              java.util.Arrays.asList(
+                  ResourceAttributes.CLOUD_AVAILABILITY_ZONE, ResourceAttributes.CLOUD_REGION),
+              "global"),
+          AttributeMapping.create("namespace", ResourceAttributes.SERVICE_NAMESPACE),
+          AttributeMapping.create("job", ResourceAttributes.SERVICE_NAME),
+          AttributeMapping.create("task_id", ResourceAttributes.SERVICE_INSTANCE_ID));
+
+  /** Converts a Java OpenTelemetyr SDK resoruce into a MonitoredResource from GCP. */
+  public static MonitoredResource mapResource(Resource resource) {
+    String platform = resource.getAttribute(ResourceAttributes.CLOUD_PLATFORM);
+    if (platform == null) {
+      return mapBase(resource, "generic_task", GENERIC_TASK_LABELS);
+    }
+    switch (platform) {
+      case ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE:
+        return mapBase(resource, "gce_instance", GCE_INSTANCE_LABELS);
+      case ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE:
+        return mapBase(resource, "k8s_pod", K8S_POD_LABELS);
+      case ResourceAttributes.CloudPlatformValues.AWS_EC2:
+        return mapBase(resource, "aws_ec2_instance", AWS_EC2_INSTANCE_LABELS);
+      default:
+        return mapBase(resource, "generic_task", GENERIC_TASK_LABELS);
+    }
+  }
+
+  private static MonitoredResource mapBase(
+      Resource resource, String mrType, List<AttributeMapping> mappings) {
+    MonitoredResource.Builder mr = MonitoredResource.newBuilder();
+    mr.setType(mrType);
+    io.opentelemetry.api.common.AttributesBuilder unused = Attributes.builder();
+    for (AttributeMapping mapping : mappings) {
+      mapping.fill(resource, mr);
+    }
+    return mr.build();
+  }
+}

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -69,11 +69,12 @@ public class ResourceTranslator {
       java.util.Arrays.asList(
           AttributeMapping.create("zone", ResourceAttributes.CLOUD_AVAILABILITY_ZONE),
           AttributeMapping.create("instance_id", ResourceAttributes.HOST_ID));
-  private static List<AttributeMapping> K8S_POD_LABELS =
+  private static List<AttributeMapping> K8S_CONTAINER_LABELS =
       java.util.Arrays.asList(
           AttributeMapping.create("location", ResourceAttributes.CLOUD_AVAILABILITY_ZONE),
           AttributeMapping.create("cluster_name", ResourceAttributes.K8S_CLUSTER_NAME),
           AttributeMapping.create("namespace_name", ResourceAttributes.K8S_NAMESPACE_NAME),
+          AttributeMapping.create("container_name", ResourceAttributes.K8S_CONTAINER_NAME),
           AttributeMapping.create("pod_name", ResourceAttributes.K8S_POD_NAME));
   private static List<AttributeMapping> AWS_EC2_INSTANCE_LABELS =
       java.util.Arrays.asList(
@@ -101,7 +102,7 @@ public class ResourceTranslator {
       case ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE:
         return mapBase(resource, "gce_instance", GCE_INSTANCE_LABELS);
       case ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE:
-        return mapBase(resource, "k8s_pod", K8S_POD_LABELS);
+        return mapBase(resource, "k8s_container", K8S_CONTAINER_LABELS);
       case ResourceAttributes.CloudPlatformValues.AWS_EC2:
         return mapBase(resource, "aws_ec2_instance", AWS_EC2_INSTANCE_LABELS);
       default:

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -57,6 +57,9 @@ public class FakeData {
 
   static final Attributes someGceAttributes =
       Attributes.builder()
+          .put(
+              ResourceAttributes.CLOUD_PLATFORM,
+              ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE)
           .put(ResourceAttributes.CLOUD_ACCOUNT_ID, aProjectId)
           .put(ResourceAttributes.HOST_ID, aHostId)
           .put(ResourceAttributes.CLOUD_AVAILABILITY_ZONE, aCloudZone)

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricExporterTest.java
@@ -175,7 +175,6 @@ public class MetricExporterTest {
             .setResource(
                 MonitoredResource.newBuilder()
                     .setType("gce_instance")
-                    .putLabels("project_id", aProjectId)
                     .putLabels("instance_id", aHostId)
                     .putLabels("zone", aCloudZone)
                     .build())
@@ -277,7 +276,6 @@ public class MetricExporterTest {
             .setResource(
                 MonitoredResource.newBuilder()
                     .setType("gce_instance")
-                    .putLabels("project_id", aProjectId)
                     .putLabels("instance_id", aHostId)
                     .putLabels("zone", aCloudZone)
                     .build())

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/ResourceTranslatorTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/ResourceTranslatorTest.java
@@ -109,9 +109,9 @@ public class ResourceTranslatorTest {
     MonitoredResource monitoredResource =
         ResourceTranslator.mapResource(Resource.create(attributes));
 
-    assertEquals("k8s_pod", monitoredResource.getType());
+    assertEquals("k8s_container", monitoredResource.getType());
     Map<String, String> monitoredResourceMap = monitoredResource.getLabelsMap();
-    assertEquals(4, monitoredResourceMap.size());
+    assertEquals(5, monitoredResourceMap.size());
 
     Map<String, String> expectedMappings =
         Stream.of(
@@ -119,7 +119,8 @@ public class ResourceTranslatorTest {
                   {"location", "country-region-zone"},
                   {"cluster_name", "GKE-cluster-name"},
                   {"namespace_name", "GKE-testNameSpace"},
-                  {"pod_name", "GKE-testHostName"}
+                  {"pod_name", "GKE-testHostName"},
+                  {"container_name", "GKE-testContainerName"}
                 })
             .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
     expectedMappings.forEach(

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/ResourceTranslatorTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/ResourceTranslatorTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.metric;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.MonitoredResource;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ResourceTranslatorTest {
+  @Test
+  public void testMapResourcesWithGCEResource() {
+    Map<AttributeKey<String>, String> testAttributes =
+        java.util.stream.Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE
+                  },
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(
+        (key, value) -> {
+          attrBuilder.put(key, value);
+        });
+    Attributes attributes = attrBuilder.build();
+
+    MonitoredResource monitoredResource =
+        ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
+
+    assertEquals("gce_instance", monitoredResource.getType());
+
+    Map<String, String> monitoredResourceMap = monitoredResource.getLabelsMap();
+    assertEquals(2, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"instance_id", "GCE-instance-id"},
+                  {"zone", "country-region-zone"},
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesWithGKEResource() {
+    Map<AttributeKey<String>, String> testAttributes =
+        Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE
+                  },
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"},
+                  {ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "GCE-instance-id"},
+                  {ResourceAttributes.HOST_NAME, "GCE-instance-name"},
+                  {ResourceAttributes.HOST_TYPE, "GCE-instance-type"},
+                  {ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"},
+                  {ResourceAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"},
+                  {ResourceAttributes.K8S_POD_NAME, "GKE-testHostName"},
+                  {ResourceAttributes.K8S_CONTAINER_NAME, "GKE-testContainerName"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(attrBuilder::put);
+    Attributes attributes = attrBuilder.build();
+
+    MonitoredResource monitoredResource =
+        ResourceTranslator.mapResource(Resource.create(attributes));
+
+    assertEquals("k8s_pod", monitoredResource.getType());
+    Map<String, String> monitoredResourceMap = monitoredResource.getLabelsMap();
+    assertEquals(4, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"location", "country-region-zone"},
+                  {"cluster_name", "GKE-cluster-name"},
+                  {"namespace_name", "GKE-testNameSpace"},
+                  {"pod_name", "GKE-testHostName"}
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesWithAwsEc2Instance() {
+    Map<AttributeKey<String>, String> testAttributes =
+        Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP},
+                  {
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AWS_EC2
+                  },
+                  {ResourceAttributes.CLOUD_ACCOUNT_ID, "aws-id"},
+                  {ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"},
+                  {ResourceAttributes.CLOUD_REGION, "country-region"},
+                  {ResourceAttributes.HOST_ID, "aws-instance-id"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(attrBuilder::put);
+    Attributes attributes = attrBuilder.build();
+
+    MonitoredResource monitoredResource =
+        ResourceTranslator.mapResource(Resource.create(attributes));
+
+    assertEquals("aws_ec2_instance", monitoredResource.getType());
+    Map<String, String> monitoredResourceMap = monitoredResource.getLabelsMap();
+    assertEquals(3, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"region", "country-region-zone"},
+                  {"instance_id", "aws-instance-id"},
+                  {"aws_account", "aws-id"}
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesWithGlobal() {
+    Map<AttributeKey<String>, String> testAttributes =
+        java.util.stream.Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.SERVICE_NAME, "my-service-name"},
+                  {ResourceAttributes.SERVICE_NAMESPACE, "prod"},
+                  {ResourceAttributes.SERVICE_INSTANCE_ID, "1234"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(
+        (key, value) -> {
+          attrBuilder.put(key, value);
+        });
+    Attributes attributes = attrBuilder.build();
+
+    MonitoredResource monitoredResource =
+        ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
+
+    assertEquals("generic_task", monitoredResource.getType());
+
+    Map<String, String> monitoredResourceMap = monitoredResource.getLabelsMap();
+    assertEquals(4, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"job", "my-service-name"},
+                  {"namespace", "prod"},
+                  {"task_id", "1234"},
+                  {"location", "global"},
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+}


### PR DESCRIPTION
This is a breaking change (and will need to be documented/major version bump), but we already have a major version bump coming for OTEL 1.16 change.

- Update resource mapping to be in-line w/ newly written collector resource mapping
- adds expanded tests for `aws_ec2_instance` and `generic_task`
- Never uses `global` resource
- Requires `cloud.platform` semconv attribute to use anything but generic_task.