### PR TITLE
Add X-Cloud-Trace-Context propagator support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,7 @@ subprojects {
 			slf4j                        : "org.slf4j:slf4j-api:${slf4jVersion}",
 			opentelemetry_api            : "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
 			opentelemetry_sdk            : "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
+			opentelemetry_autoconfigure_spi : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${openTelemetryVersion}",
 			opentelemetry_autoconfigure  : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}-alpha",
 			opentelemetry_semconv        : "io.opentelemetry:opentelemetry-semconv:${openTelemetryVersion}-alpha",
 			opentelemetry_sdk_metrics    : "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}-alpha",

--- a/detectors/resources/gradle.properties
+++ b/detectors/resources/gradle.properties
@@ -1,2 +1,2 @@
 release.qualifier=alpha
-release.enabled=false
+release.enabled=true

--- a/e2e-test-server/build.gradle
+++ b/e2e-test-server/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	compile(libraries.google_cloud_trace)
 	compile(libraries.google_cloud_pubsub)
 	compile project(':exporter-trace')
+	compile project(':propagators-gcp')
 	runtimeOnly project(':detector-resources')
 }
 

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -198,9 +198,9 @@ public class ScenarioHandlerManager {
         public String get(Map<String, String> carrier, String key) {
           // We need to ignore case on keys.
           for (String rawKey : carrier.keySet()) {
-              if (rawKey.toLowerCase(Locale.ROOT) == key) {
-                  return carrier.get(rawKey);
-              }
+            if (rawKey.toLowerCase(Locale.ROOT) == key) {
+              return carrier.get(rawKey);
+            }
           }
           return null;
         }

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -207,7 +207,7 @@ public class ScenarioHandlerManager {
           LOGGER.info("Looking for header key: " + key);
           // We need to ignore case on keys.
           for (String rawKey : carrier.keySet()) {
-            if (rawKey.toLowerCase(Locale.getDefault()) == key) {
+            if (rawKey.toLowerCase(Locale.ENGLISH).equals(key)) {
               LOGGER.info("Found key: " + rawKey + ", value: " + carrier.get(rawKey));
               return carrier.get(rawKey);
             }

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -32,6 +32,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -78,7 +79,9 @@ public class ScenarioHandlerManager {
 
   /** Basic trace test. */
   private Response basicPropagator(Request request) {
-    LOGGER.info("Running basicPropagator test, request: " + request);
+    LOGGER.info(
+        "Running basicPropagator test, request headers: "
+            + Arrays.toString(request.headers().entrySet().toArray()));
     // TODO - extract headers from request using text-map-propagators.
     return withTemporaryOtel(
         (ctx) -> {
@@ -204,8 +207,8 @@ public class ScenarioHandlerManager {
           LOGGER.info("Looking for header key: " + key);
           // We need to ignore case on keys.
           for (String rawKey : carrier.keySet()) {
-            if (rawKey.toLowerCase(Locale.ROOT) == key) {
-              LOGGER.info("Found: " + carrier.get(rawKey));
+            if (rawKey.toLowerCase(Locale.getDefault()) == key) {
+              LOGGER.info("Found key: " + rawKey + ", value: " + carrier.get(rawKey));
               return carrier.get(rawKey);
             }
           }

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -33,6 +33,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -88,6 +89,8 @@ public class ScenarioHandlerManager {
                 ctx.getTestTracer()
                     .spanBuilder("basicPropagator")
                     .setAttribute(Constants.TEST_ID, request.testId())
+                    // TODO - This shouldn't be needed.
+                    .setParent(remoteCtx)
                     .startSpan();
             try {
               return Response.ok(Map.of(Constants.TRACE_ID, span.getSpanContext().getTraceId()));
@@ -193,7 +196,13 @@ public class ScenarioHandlerManager {
 
         @Override
         public String get(Map<String, String> carrier, String key) {
-          return carrier.get(key);
+          // We need to ignore case on keys.
+          for (String rawKey : carrier.keySet()) {
+              if (rawKey.toLowerCase(Locale.ROOT) == key) {
+                  return carrier.get(rawKey);
+              }
+          }
+          return null;
         }
       };
 }

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation(project(':detector-resources')) {
 		exclude group: 'io.opentelemetry'
 	}
+	implementation(project(':propagators-gcp')) {
+		exclude group: 'io.opentelemetry'
+	}
 }
 
 

--- a/propagators/README.md
+++ b/propagators/README.md
@@ -1,0 +1,3 @@
+# Propagators
+
+This directory contains various TextMapPropagator extensions for the OpenTelemetry SDK.

--- a/propagators/gcp/README.md
+++ b/propagators/gcp/README.md
@@ -1,0 +1,39 @@
+# Google X-Cloud-Trace-Context propagtors
+
+[![Maven Central][maven-image]][maven-url]
+
+*NOTE: While OpenTelemetry SDK is stable, the Autoconfigure SDK extension is still Alpha in OpenTelemetry, and some features are not guaranteed to work across versions.*
+
+This module allows attaching trace context with Google Cloud's [X-Cloud-Trace-Context header](https://cloud.google.com/trace/docs/setup#force-trace).
+
+
+## Setup
+
+The preferred mechanism is to use the [SDK autoconfigure extension](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure).
+
+- Add a runtime dependency from your java project to this library.
+- You can now use `oneway-gcp` and `gcp` as viable propagation strings in [the `otel.propagators` flag](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#propagator)
+
+
+## Manual Configuration
+
+Instead of configuring with the SDK autoconfigure extension, you can instead directly register this propagator as 
+follows:
+
+```java
+public class MyMain {
+    public static void main(String[] args) {
+        ContextPropagators propagators = ContextPropagators.create(
+            TextMapPropagator.composite(
+                W3CTraceContextPropagator.getInstance(),
+                new XCloudTraceContextPropagator(/*oneway=*/true)));
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+            .setPropagators(propagators)
+            // Other setup
+            .build();
+    }
+}
+```
+
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/propagators-gcp/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/propagators-gcp

--- a/propagators/gcp/build.gradle
+++ b/propagators/gcp/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+description = 'Google Cloud Trace Context propogators'
+
+dependencies {
+	api(libraries.auto_service_annotations)
+	annotationProcessor(libraries.auto_service)
+	implementation(libraries.opentelemetry_api)
+	implementation(libraries.opentelemetry_autoconfigure_spi)
+	testImplementation(testLibraries.assertj)
+	testImplementation(testLibraries.junit)
+	testImplementation(testLibraries.opentelemetry_sdk_testing)
+	testImplementation(libraries.opentelemetry_autoconfigure)
+}

--- a/propagators/gcp/gradle.properties
+++ b/propagators/gcp/gradle.properties
@@ -1,0 +1,2 @@
+release.qualifier=alpha
+release.enabled=true

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/OneWayXCloudTraceConfigurablePropagatorProvider.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/OneWayXCloudTraceConfigurablePropagatorProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.propagators;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * Autoconfigurable propagator for OpenTelemetry Java SDK that only attaches to existing
+ * X-Cloud-Trace-Context traces and does not create downstream ones.
+ *
+ * <p>Note: This is the preferred mechanism of propagation as X-Cloud-Trace-Context sampling flag
+ * behaves subtly different from expectations in both w3c traceparent *and* opentelemetry
+ * propagation.
+ */
+@AutoService(ConfigurablePropagatorProvider.class)
+public class OneWayXCloudTraceConfigurablePropagatorProvider
+    implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator(ConfigProperties config) {
+    return new XCloudTraceContextPropagator(true);
+  }
+
+  @Override
+  public String getName() {
+    return "oneway-gcp";
+  }
+}

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceConfigurablePropagatorProvider.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceConfigurablePropagatorProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.propagators;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * Autoconfigurable propagator for OpenTelemetry Java SDK that will make use of
+ * X-Cloud-Trace-Context header.
+ *
+ * <p>Note: This is *NOT* the recommended propagation as X-Cloud-Trace-Context because the sampling
+ * flag behaves subtly different from expectations in both w3c traceparent *and* opentelemetry
+ * propagation.
+ *
+ * @see {@link OneWayXCloudTraceConfigurablePropagatorProvider}
+ */
+@AutoService(ConfigurablePropagatorProvider.class)
+public class XCloudTraceConfigurablePropagatorProvider implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator(ConfigProperties config) {
+    return new XCloudTraceContextPropagator(false);
+  }
+
+  @Override
+  public String getName() {
+    return "gcp";
+  }
+}

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.propagators;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A context propagator that leverages the X-Cloud-Trace-Context header.
+ *
+ * <p>See: <a href="https://cloud.google.com/trace/docs/setup#force-trace">Google Cloud Trace
+ * Documentation</a> for details.
+ */
+public final class XCloudTraceContextPropagator implements TextMapPropagator {
+
+  private static String FIELD = "x-cloud-trace-context";
+  private static Collection<String> FIELDS = Collections.singletonList(FIELD);
+  private static Pattern VALUE_PATTERN =
+      Pattern.compile("(?<traceid>[0-9a-f]{32})\\/(?<spanid>[\\d]{1,20});o=(?<sampled>\\d+)");
+  private static Logger LOGGER = Logger.getLogger("XCloudTraceContextPropogator");
+
+  private final boolean oneway;
+
+  /**
+   * Constructs a new text map propogator that leverages the X-Cloud-Trace-Context header.
+   *
+   * @param oneway
+   */
+  public XCloudTraceContextPropagator(boolean oneway) {
+    this.oneway = oneway;
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return FIELDS;
+  }
+
+  @Override
+  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+    // We never inject cloud trace context information in oneway mode.
+    if (oneway) {
+      return;
+    }
+    Span current = Span.fromContext(context);
+    if (!current.getSpanContext().isValid()) {
+      return;
+    }
+    String sampledString = current.getSpanContext().isSampled() ? "1" : "0";
+    String spanIdString =
+        java.lang.Long.toUnsignedString(
+            java.lang.Long.parseUnsignedLong(current.getSpanContext().getSpanId(), 16));
+    String value =
+        current.getSpanContext().getTraceId() + "/" + spanIdString + ";o=" + sampledString;
+    setter.set(carrier, FIELD, value);
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+    if (context == null || getter == null) {
+      return context;
+    }
+    // Ignore the scenario where another propagator already filled out a field.
+    if (Span.fromContext(context).getSpanContext().isRemote()) {
+      return context;
+    }
+    // TODO - Do we need to iterate over keys and lowercase them, or is java doing that for us?
+    String value = getter.get(carrier, FIELD);
+    if (value == null) {
+      return context;
+    }
+    Matcher matcher = VALUE_PATTERN.matcher(value);
+    if (!matcher.matches()) {
+      LOGGER.fine(() -> "Found x-cloud-trace-context header with invalid format: " + value);
+      return context;
+    }
+    String traceId = matcher.group("traceid");
+    if (!TraceId.isValid(traceId)) {
+      LOGGER.warning(
+          () ->
+              "Found x-cloud-trace-context header with invalid trace: "
+                  + traceId
+                  + ", header: "
+                  + value);
+      return context;
+    }
+    String spanId = SpanId.fromLong(java.lang.Long.parseUnsignedLong(matcher.group("spanid")));
+    if (!SpanId.isValid(spanId)) {
+      LOGGER.warning(
+          () ->
+              "Found x-cloud-trace-context header with invalid span: "
+                  + spanId
+                  + ", header: "
+                  + value);
+      return context;
+    }
+    boolean sampled = "1".equals(matcher.group("sampled"));
+    SpanContext parent =
+        SpanContext.createFromRemoteParent(
+            traceId,
+            spanId,
+            sampled ? TraceFlags.getSampled() : TraceFlags.getDefault(),
+            TraceState.getDefault());
+    return context.with(Span.wrap(parent));
+  }
+}

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.propagators;
+
+import static org.junit.Assert.assertTrue;
+
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AutoConfigureTest {
+
+  @Test
+  public void findsWithServiceLoader() {
+    ServiceLoader<ConfigurablePropagatorProvider> services =
+        ServiceLoader.load(ConfigurablePropagatorProvider.class, getClass().getClassLoader());
+    assertTrue(
+        "Could not load gcp_oneway propagator using serviceloader, found: " + services,
+        services.stream()
+            .anyMatch(
+                provider ->
+                    provider.type().equals(OneWayXCloudTraceConfigurablePropagatorProvider.class)));
+
+    assertTrue(
+        "Could not load gcp propagator using serviceloader, found: " + services,
+        services.stream()
+            .anyMatch(
+                provider ->
+                    provider.type().equals(XCloudTraceConfigurablePropagatorProvider.class)));
+  }
+
+  @Test
+  public void findsWithAutoConfigure() {
+    assertTrue(
+        findsWithAutoConfigure("oneway-gcp").getTextMapPropagator()
+            instanceof XCloudTraceContextPropagator);
+    assertTrue(
+        findsWithAutoConfigure("gcp").getTextMapPropagator()
+            instanceof XCloudTraceContextPropagator);
+  }
+
+  private static ContextPropagators findsWithAutoConfigure(String propagator) {
+    AutoConfiguredOpenTelemetrySdk sdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .setResultAsGlobal(false)
+            .registerShutdownHook(false)
+            .addPropertiesSupplier(
+                () -> Map.of("otel.propagators", propagator, "otel.traces.exporter", "none"))
+            .build();
+    return sdk.getOpenTelemetrySdk().getPropagators();
+  }
+}

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.propagators;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PropagatorTest {
+
+  private static TextMapGetter<Map<String, String>> GETTER =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @Test
+  public void testExtractSampled() {
+    Context context = Context.root();
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("x-cloud-trace-context", "00000000000000000000000000000010/15;o=1");
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(false);
+
+    // Now try to extract the value.
+    Context updated = propagator.extract(context, carrier, GETTER);
+    Span span = Span.fromContext(updated);
+    Assert.assertNotNull(span);
+    Assert.assertEquals("00000000000000000000000000000010", span.getSpanContext().getTraceId());
+    Assert.assertEquals("000000000000000f", span.getSpanContext().getSpanId());
+    Assert.assertEquals(true, span.getSpanContext().getTraceFlags().isSampled());
+  }
+
+  @Test
+  public void testExtractOneway() {
+    Context context = Context.root();
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("x-cloud-trace-context", "00000000000000000000000000000010/15;o=1");
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(true);
+
+    // Now try to extract the value.
+    Context updated = propagator.extract(context, carrier, GETTER);
+    Span span = Span.fromContext(updated);
+    Assert.assertNotNull(span);
+    Assert.assertEquals("00000000000000000000000000000010", span.getSpanContext().getTraceId());
+    Assert.assertEquals("000000000000000f", span.getSpanContext().getSpanId());
+    Assert.assertEquals(true, span.getSpanContext().getTraceFlags().isSampled());
+  }
+
+  @Test
+  public void testExtractNotSampled() {
+    Context context = Context.root();
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("x-cloud-trace-context", "00000000000000000000000000000011/31;o=0");
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(false);
+
+    // Now try to extract the value.
+    Context updated = propagator.extract(context, carrier, GETTER);
+    Span span = Span.fromContext(updated);
+    Assert.assertNotNull(span);
+    Assert.assertEquals("00000000000000000000000000000011", span.getSpanContext().getTraceId());
+    Assert.assertEquals("000000000000001f", span.getSpanContext().getSpanId());
+    Assert.assertEquals(false, span.getSpanContext().getTraceFlags().isSampled());
+  }
+
+  @Test
+  public void testNotInjectOneway() {
+    Span span =
+        Span.wrap(
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+    Context context = Context.root().with(span);
+    Map<String, String> carrier = new HashMap<>();
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(true);
+
+    // Now try to inject the value.
+    propagator.inject(context, carrier, Map::put);
+    Assert.assertNull(carrier.get("x-cloud-trace-context"));
+  }
+
+  @Test
+  public void testInjectSampled() {
+    Span span =
+        Span.wrap(
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+    Context context = Context.root().with(span);
+    Map<String, String> carrier = new HashMap<>();
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(false);
+
+    // Now try to inject the value.
+    propagator.inject(context, carrier, Map::put);
+    Assert.assertEquals(
+        "00000000000000000000000000000001/2;o=1", carrier.get("x-cloud-trace-context"));
+  }
+
+  @Test
+  public void testInjectNotSampled() {
+    Span span =
+        Span.wrap(
+            SpanContext.create(
+                "00000000000000000000000000000002",
+                "0000000000000013",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()));
+    Context context = Context.root().with(span);
+    Map<String, String> carrier = new HashMap<>();
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(false);
+
+    // Now try to inject the value.
+    propagator.inject(context, carrier, Map::put);
+    // Note - SpanID is hex (otel) -> decimal (gcp)
+    Assert.assertEquals(
+        "00000000000000000000000000000002/19;o=0", carrier.get("x-cloud-trace-context"));
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ include ":examples-resource"
 include ":detector-resources"
 include ":e2e-test-server"
 include ":examples-spring"
+include ":propagators-gcp"
 
 project(':exporter-trace').projectDir =
 		"$rootDir/exporters/trace" as File
@@ -68,3 +69,6 @@ project(':examples-autoinstrument').projectDir =
 
 project(':examples-autoconf').projectDir =
 		"$rootDir/examples/autoconf" as File
+
+project(':propagators-gcp').projectDir =
+		"$rootDir/propagators/gcp" as File


### PR DESCRIPTION
- Pushes the `oneway` option as best-path for now
- Keeps similar implementation to Go/Python

Depends on / includes #145 