### PR TITLE
Increase cloud monitoring client timeout to 12 s

### DIFF
--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -64,7 +64,7 @@ public abstract class MetricConfiguration {
   /**
    * Returns the deadline for exporting to Cloud Monitoring backend.
    *
-   * <p>Default value is 10 seconds.
+   * <p>Default value is {@value #DEFAULT_DEADLINE}.
    *
    * @return the export deadline.
    */

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -39,7 +39,7 @@ public abstract class MetricConfiguration {
 
   private static final String DEFAULT_PROJECT_ID =
       Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
-  private static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
+  private static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(12, 0); // Consistent with Cloud Monitoring's timeout
 
   MetricConfiguration() {}
 

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -39,7 +39,8 @@ public abstract class MetricConfiguration {
 
   private static final String DEFAULT_PROJECT_ID =
       Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
-  private static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(12, 0); // Consistent with Cloud Monitoring's timeout
+  private static final Duration DEFAULT_DEADLINE =
+      Duration.ofSeconds(12, 0); // Consistent with Cloud Monitoring's timeout
 
   MetricConfiguration() {}
 


### PR DESCRIPTION
This matches the internal value in Cloud Monitoring and avoids
DEADLINE_EXCEEDED RPC errors.