### PR TITLE
Pr/enable detect resource

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.10.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.10.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.10.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:latest
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -98,7 +98,7 @@ public class ScenarioHandlerManager {
           Tracer tracer = sdk.getTestTracer();
           Span span =
               tracer
-                  .spanBuilder("detectResource")
+                  .spanBuilder("resourceDetectionTrace")
                   .setAttribute(Constants.TEST_ID, request.testId())
                   .startSpan();
           try {


### PR DESCRIPTION
### Issue
The `detectResource` scenario is already enabled in [ScenarioHandlerManager](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/blob/main/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java#L57) and should run the tests for existing GCE, GKE & local detectors. 

### Fix
Updates the test runner image to the latest tag - so that test runner can call the `detectResource` scenario. Also fixes a name mismatch which led to the failure of `TestResourceDetectionTrace` test. 

### Testing
- Ran tests against the locally built  test runner image. The tests ran as expected in the local environment. 
- The checks in PR will confirm test runs against the GCE and GKE environments.  
