### PR TITLE
Pr/enable gae resource detection

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -45,5 +45,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.14.1
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.13.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -24,7 +24,7 @@ steps:
 
   # Run the test
   - name: $_TEST_RUNNER_IMAGE
-    id: run-tests-cloudrun
+    id: run-tests-gae
     dir: /
     env: [ "PROJECT_ID=$PROJECT_ID" ]
     args:

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.14.1
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Wait for the image to exist
+  - name: "docker"
+    id: wait-for-image
+    entrypoint: "sh"
+    timeout: 3m
+    env: [ "_TEST_SERVER_IMAGE=${_TEST_SERVER_IMAGE}" ]
+    args:
+      - e2e-test-server/wait-for-image.sh
+
+  # Run the test
+  - name: $_TEST_RUNNER_IMAGE
+    id: run-tests-cloudrun
+    dir: /
+    env: [ "PROJECT_ID=$PROJECT_ID" ]
+    args:
+      - gae
+      - --image=$_TEST_SERVER_IMAGE
+      - --runtime=java11
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+substitutions:
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.14.1
+  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.13.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.13.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.13.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
@@ -60,6 +60,7 @@ public class AttributesExtractorUtil {
    * <ul>
    *   <li>If the cloud region cannot be found, calling this method has no effect.
    *   <li>Calling this method will update {@link ResourceAttributes#CLOUD_REGION} attribute.
+   *   <li>This method uses zone attribute to parse region from it.
    * </ul>
    *
    * <p>Example region: australia-southeast1
@@ -69,7 +70,7 @@ public class AttributesExtractorUtil {
    * @param metadataConfig The {@link GCPMetadataConfig} from which the cloud region value is
    *     extracted.
    */
-  public static void addCloudRegionFromMetadata(
+  public static void addCloudRegionFromMetadataUsingZone(
       AttributesBuilder attributesBuilder, GCPMetadataConfig metadataConfig) {
     String zone = metadataConfig.getZone();
     if (zone != null) {

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
@@ -83,6 +83,31 @@ public class AttributesExtractorUtil {
   }
 
   /**
+   * Utility method to extract the cloud region from passed {@link GCPMetadataConfig}. The method
+   * modifies the passed attributesBuilder by adding the extracted property to it.
+   *
+   * <ul>
+   *   <li>If the cloud region cannot be found, calling this method has no effect.
+   *   <li>Calling this method will update {@link ResourceAttributes#CLOUD_REGION} attribute.
+   *   <li>This method directly uses the region attribute from the metadata config.
+   * </ul>
+   *
+   * <p>Example region: australia-southeast1
+   *
+   * @param attributesBuilder The {@link AttributesBuilder} to which the extracted property needs to
+   *     be added.
+   * @param metadataConfig The {@link GCPMetadataConfig} from which the cloud region value is
+   *     extracted.
+   */
+  public static void addCloudRegionFromMetadataUsingRegion(
+      AttributesBuilder attributesBuilder, GCPMetadataConfig metadataConfig) {
+    String region = metadataConfig.getRegion();
+    if (region != null) {
+      attributesBuilder.put(ResourceAttributes.CLOUD_REGION, region);
+    }
+  }
+
+  /**
    * Utility method to extract the current compute instance ID from the passed {@link
    * GCPMetadataConfig}. The method modifies the passed attributesBuilder by adding the extracted
    * property to it.

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/CloudRunResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/CloudRunResource.java
@@ -61,7 +61,7 @@ public final class CloudRunResource implements ResourceProvider {
       }
 
       AttributesExtractorUtil.addAvailabilityZoneFromMetadata(attrBuilders, metadata);
-      AttributesExtractorUtil.addCloudRegionFromMetadata(attrBuilders, metadata);
+      AttributesExtractorUtil.addCloudRegionFromMetadataUsingZone(attrBuilders, metadata);
       AttributesExtractorUtil.addInstanceIdFromMetadata(attrBuilders, metadata);
     }
 

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GAEResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GAEResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.detectors;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+public class GAEResource implements ResourceProvider {
+  private final GCPMetadataConfig metadata;
+  private final EnvVars envVars;
+
+  public GAEResource() {
+    this.metadata = GCPMetadataConfig.DEFAULT_INSTANCE;
+    this.envVars = EnvVars.DEFAULT_INSTANCE;
+  }
+
+  // For testing only
+  GAEResource(GCPMetadataConfig metadata, EnvVars envVars) {
+    this.metadata = metadata;
+    this.envVars = envVars;
+  }
+
+  public Attributes getAttributes() {
+    if (!metadata.isRunningOnGcp()) {
+      return Attributes.empty();
+    }
+
+    AttributesBuilder attrBuilders = Attributes.builder();
+    attrBuilders.put(ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP);
+
+    if (envVars.get("GAE_SERVICE") != null) {
+      // add the resource attributes for App Engine
+      attrBuilders.put(
+          ResourceAttributes.CLOUD_PLATFORM, ResourceAttributes.CloudPlatformValues.GCP_APP_ENGINE);
+
+      String appModuleName = envVars.get("GAE_SERVICE");
+      if (appModuleName != null) {
+        attrBuilders.put(ResourceAttributes.FAAS_NAME, appModuleName);
+      }
+
+      String appVersionId = envVars.get("GAE_VERSION");
+      if (appVersionId != null) {
+        attrBuilders.put(ResourceAttributes.FAAS_VERSION, appVersionId);
+      }
+
+      String appInstanceId = envVars.get("GAE_INSTANCE");
+      if (appInstanceId != null) {
+        attrBuilders.put(ResourceAttributes.FAAS_ID, appInstanceId);
+      }
+
+      AttributesExtractorUtil.addCloudRegionFromMetadata(attrBuilders, metadata);
+    }
+    return attrBuilders.build();
+  }
+
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return Resource.create(getAttributes());
+  }
+}

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GAEResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GAEResource.java
@@ -65,7 +65,7 @@ public class GAEResource implements ResourceProvider {
         attrBuilders.put(ResourceAttributes.FAAS_ID, appInstanceId);
       }
 
-      AttributesExtractorUtil.addCloudRegionFromMetadata(attrBuilders, metadata);
+      AttributesExtractorUtil.addCloudRegionFromMetadataUsingZone(attrBuilders, metadata);
     }
     return attrBuilders.build();
   }

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCEResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCEResource.java
@@ -51,7 +51,7 @@ public final class GCEResource implements ResourceProvider {
     }
 
     AttributesExtractorUtil.addAvailabilityZoneFromMetadata(attrBuilders, metadata);
-    AttributesExtractorUtil.addCloudRegionFromMetadata(attrBuilders, metadata);
+    AttributesExtractorUtil.addCloudRegionFromMetadataUsingZone(attrBuilders, metadata);
 
     String instanceId = metadata.getInstanceId();
     if (instanceId != null) {

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCFResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCFResource.java
@@ -62,7 +62,7 @@ public final class GCFResource implements ResourceProvider {
       }
 
       AttributesExtractorUtil.addAvailabilityZoneFromMetadata(attrBuilders, metadata);
-      AttributesExtractorUtil.addCloudRegionFromMetadata(attrBuilders, metadata);
+      AttributesExtractorUtil.addCloudRegionFromMetadataUsingZone(attrBuilders, metadata);
       AttributesExtractorUtil.addInstanceIdFromMetadata(attrBuilders, metadata);
     }
 

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCFResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCFResource.java
@@ -46,7 +46,7 @@ public final class GCFResource implements ResourceProvider {
     attrBuilders.put(ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP);
 
     if (envVars.get("FUNCTION_TARGET") != null) {
-      // add the resource attributes for Cloud Run
+      // add the resource attributes for Cloud Function
       attrBuilders.put(
           ResourceAttributes.CLOUD_PLATFORM,
           ResourceAttributes.CloudPlatformValues.GCP_CLOUD_FUNCTIONS);

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPMetadataConfig.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPMetadataConfig.java
@@ -62,6 +62,18 @@ final class GCPMetadataConfig {
     return zone;
   }
 
+  // Use this method only when the region cannot be parsed from the zone. Known use-cases of this
+  // method involve detecting region in GAE standard environment
+  // Example response: projects/5689182099321/regions/us-central1
+  // Returns null on failure to retrieve from metadata server
+  String getRegion() {
+    String region = getAttribute("instance/region");
+    if (region != null && region.contains("/")) {
+      region = region.substring(region.lastIndexOf('/') + 1);
+    }
+    return region;
+  }
+
   // Example response: projects/640212054955/machineTypes/e2-medium
   String getMachineType() {
     String machineType = getAttribute("instance/machine-type");

--- a/detectors/resources/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/detectors/resources/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -2,3 +2,4 @@ com.google.cloud.opentelemetry.detectors.GCEResource
 com.google.cloud.opentelemetry.detectors.GKEResource
 com.google.cloud.opentelemetry.detectors.CloudRunResource
 com.google.cloud.opentelemetry.detectors.GCFResource
+com.google.cloud.opentelemetry.detectors.GAEResource

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GAEResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GAEResourceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.detectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.junit.Assert.*;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GAEResourceTest {
+  @Rule public final WireMockRule wireMockRule = new WireMockRule(8089);
+  private final GCPMetadataConfig metadataConfig = new GCPMetadataConfig("http://localhost:8089/");
+  private static final Map<String, String> envVars = new HashMap<>();
+
+  @BeforeClass
+  public static void setup() {
+    envVars.put("GAE_SERVICE", "app-engine-hello");
+    envVars.put("GAE_VERSION", "app-engine-hello-v1");
+    envVars.put("GAE_INSTANCE", "app-engine-hello-f236d");
+  }
+
+  @Test
+  public void findsWithServiceLoader() {
+    ServiceLoader<ResourceProvider> services =
+        ServiceLoader.load(ResourceProvider.class, getClass().getClassLoader());
+    assertTrue(
+        "Could not load AppEngine Resource detector using serviceloader, found: " + services,
+        services.stream().anyMatch(provider -> provider.type().equals(GAEResource.class)));
+  }
+
+  @Test
+  public void testAppEngineNotGCP() {
+    GAEResource testResource = new GAEResource();
+
+    // The default metadata url is unreachable through testing so getAttributes should not detect a
+    // GCP environment, hence returning empty attributes.
+    assertThat(testResource.getAttributes()).isEmpty();
+  }
+
+  @Test
+  public void testAppEngineResourceNonGCPEndpoint() {
+    // intentionally not providing the required Metadata-Flovor header with the
+    // request to mimic non GCP endpoint
+    stubFor(
+        get(urlEqualTo("/project/project-id"))
+            .willReturn(aResponse().withBody("nonGCPendpointTest")));
+    GAEResource testResource = new GAEResource(metadataConfig, new EnvVarMock(envVars));
+    assertThat(testResource.getAttributes()).isEmpty();
+  }
+
+  @Test
+  public void testAppEngineResourceWithAppEngineAttributesSucceeds() {
+    stubEndpoint("/project/project-id", "GCF-pid");
+    stubEndpoint("/instance/zone", "country-region-zone");
+    stubEndpoint("/instance/id", "GCF-instance-id");
+
+    GAEResource testResource = new GAEResource(metadataConfig, new EnvVarMock(envVars));
+    assertThat(testResource.getAttributes())
+        .hasSize(6)
+        .containsEntry(
+            ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP)
+        .containsEntry(
+            ResourceAttributes.CLOUD_PLATFORM,
+            ResourceAttributes.CloudPlatformValues.GCP_APP_ENGINE)
+        .containsEntry(ResourceAttributes.CLOUD_REGION, "country-region")
+        .containsEntry(ResourceAttributes.FAAS_NAME, envVars.get("GAE_SERVICE"))
+        .containsEntry(ResourceAttributes.FAAS_VERSION, envVars.get("GAE_VERSION"))
+        .containsEntry(ResourceAttributes.FAAS_ID, envVars.get("GAE_INSTANCE"));
+  }
+
+  // Helper method to help stub endpoints
+  private void stubEndpoint(String endpointPath, String responseBody) {
+    stubFor(
+        get(urlEqualTo(endpointPath))
+            .willReturn(
+                aResponse().withHeader("Metadata-Flavor", "Google").withBody(responseBody)));
+  }
+}

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -95,6 +95,12 @@ public class ResourceTranslator {
       java.util.Arrays.asList(
           AttributeMapping.create("region", ResourceAttributes.CLOUD_REGION),
           AttributeMapping.create("function_name", ResourceAttributes.FAAS_NAME));
+  private static List<AttributeMapping> GOOGLE_CLOUD_APP_ENGINE_INSTANCE_LABELS =
+      java.util.Arrays.asList(
+          AttributeMapping.create("module_id", ResourceAttributes.FAAS_NAME),
+          AttributeMapping.create("version_id", ResourceAttributes.FAAS_VERSION),
+          AttributeMapping.create("instance_id", ResourceAttributes.FAAS_ID),
+          AttributeMapping.create("location", ResourceAttributes.CLOUD_REGION));
   private static List<AttributeMapping> GENERIC_TASK_LABELS =
       java.util.Arrays.asList(
           AttributeMapping.create(
@@ -123,6 +129,8 @@ public class ResourceTranslator {
         return mapBase(resource, "cloud_run_revision", GOOGLE_CLOUD_RUN_INSTANCE_LABELS);
       case ResourceAttributes.CloudPlatformValues.GCP_CLOUD_FUNCTIONS:
         return mapBase(resource, "cloud_function", GOOGLE_CLOUD_FUNCTION_INSTANCE_LABELS);
+      case ResourceAttributes.CloudPlatformValues.GCP_APP_ENGINE:
+        return mapBase(resource, "gae_instance", GOOGLE_CLOUD_APP_ENGINE_INSTANCE_LABELS);
       default:
         return mapBase(resource, "generic_task", GENERIC_TASK_LABELS);
     }


### PR DESCRIPTION
### Description

This PR makes the following changes - 
 - Adds resource detection capabilities for GAE (Google App Engine) environments. 
 - Adds steps for cloudbuild in YAML to support automated test runs (_In order to enable the trigger properly, a version update to the e2e-testing image will be required_).

### Testing 
 - Built a docker image for the instrumented test server manually provided it to the e2e test runner, testing it specifically with the GAE arguments. 
      - All tests passed. 

### Notes on GitHub checks - 
 - ~~`ops-java-e2e-gae` will pass once [this PR](https://github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/pull/17) is merged and the new version of e2e-test-runner is used in `cloudbuild-e2e-gae.yaml`.~~  PR is merged.
 -  ~~All checks except `ops-java-e2e-gae` should pass.~~ All checks should pass now. 