### PR TITLE
Remove repo level allstar configs

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,2 +1,0 @@
-optConfig:
-  optIn: true

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,3 +1,0 @@
-optConfig:
-  optIn: true
-action: issue

--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,3 +1,0 @@
-optConfig:
-  optIn: true
-action: issue

--- a/.allstar/outside.yaml
+++ b/.allstar/outside.yaml
@@ -1,3 +1,0 @@
-optConfig:
-  optIn: true
-action: issue

--- a/.allstar/security.yaml
+++ b/.allstar/security.yaml
@@ -1,3 +1,0 @@
-optConfig:
-  optIn: true
-action: issue


### PR DESCRIPTION
The configurations work, but they may turn out to be duplicates since they need to be enabled at the org level. 

Due to this configuration, [these issues](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues?q=is%3Aissue+label%3Aallstar+) were auto-generated. 

Removing these configs from the repo level for now. The auto generated issues will be closed after this PR is merged.  