### PR TITLE
Replaced concrete type TraceExporter with interface type SpanExporter

### DIFF
--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -32,6 +32,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -216,7 +217,7 @@ public class ScenarioHandlerManager {
             .setProjectId(Constants.PROJECT_ID != "" ? Constants.PROJECT_ID : null)
             .build();
 
-    TraceExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
+    SpanExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
     // Register the TraceExporter with OpenTelemetry
     return OpenTelemetrySdk.builder()
         .setPropagators(

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -24,6 +24,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Random;
@@ -40,7 +41,7 @@ public class TraceExporterExample {
         TraceConfiguration.builder().setDeadline(Duration.ofMillis(30000)).build();
 
     try {
-      TraceExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
+      SpanExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
       // Register the TraceExporter with OpenTelemetry
       return OpenTelemetrySdk.builder()
           .setTracerProvider(

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -52,12 +52,12 @@ public class TraceExporter implements SpanExporter {
       Map.of("User-Agent", "opentelemetry-operations-java/" + TraceVersions.EXPORTER_VERSION);
   private static final HeaderProvider HEADER_PROVIDER = () -> HEADERS;
 
-  public static TraceExporter createWithDefaultConfiguration() throws IOException {
+  public static SpanExporter createWithDefaultConfiguration() throws IOException {
     TraceConfiguration configuration = TraceConfiguration.builder().build();
     return TraceExporter.createWithConfiguration(configuration);
   }
 
-  public static TraceExporter createWithConfiguration(TraceConfiguration configuration)
+  public static SpanExporter createWithConfiguration(TraceConfiguration configuration)
       throws IOException {
     String projectId = configuration.getProjectId();
     TraceServiceStub stub = configuration.getTraceServiceStub();

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -27,6 +27,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +56,7 @@ public class EndToEndTest {
   private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
   private static final StatusData SPAN_DATA_STATUS = StatusData.ok();
 
-  private TraceExporter exporter;
+  private SpanExporter exporter;
 
   /** A test-container instance that loads the Cloud-Ops-Mock server container. */
   private static class CloudOperationsMockContainer

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.opentelemetry.trace;
 
 import static org.junit.Assert.assertNotNull;
 
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +30,7 @@ public class TraceExporterTest {
   public void createWithConfiguration() {
     TraceConfiguration configuration = TraceConfiguration.builder().setProjectId("test").build();
     try {
-      TraceExporter exporter = TraceExporter.createWithConfiguration(configuration);
+      SpanExporter exporter = TraceExporter.createWithConfiguration(configuration);
 
       assertNotNull(exporter);
     } catch (IOException ignored) {


### PR DESCRIPTION
### Breaking Change
 - Replacing the usages of concrete type `TraceExporter` with interface type `SpanExporter` for public methods in `TraceExporter` class.

This change should help with the future work of adding a Lazy initialized / Deferred trace exporter. 


