### PR TITLE
Lazy load project ID in TraceConfiguration

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -228,7 +228,13 @@ public abstract class TraceConfiguration {
      */
     public TraceConfiguration build() {
       // If project ID is not set, attempt to get the Default Project ID
-      if (Strings.isNullOrEmpty(getProjectId())) {
+      String currentProjectId;
+      try {
+        currentProjectId = getProjectId();
+      } catch (IllegalStateException e) {
+        currentProjectId = null;
+      }
+      if (Strings.isNullOrEmpty(currentProjectId)) {
         setProjectId(Strings.nullToEmpty(ServiceOptions.getDefaultProjectId()));
       }
       // Make a defensive copy of fixed attributes.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -25,20 +25,18 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 
 /** Configurations for {@link TraceExporter}. */
 @AutoValue
 @Immutable
 public abstract class TraceConfiguration {
-
-  private static final String DEFAULT_PROJECT_ID =
-      Strings.nullToEmpty(ServiceOptions.getDefaultProjectId());
 
   @VisibleForTesting static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(10, 0);
 
@@ -127,7 +125,6 @@ public abstract class TraceConfiguration {
    */
   public static Builder builder() {
     return new AutoValue_TraceConfiguration.Builder()
-        .setProjectId(DEFAULT_PROJECT_ID)
         .setFixedAttributes(Collections.emptyMap())
         .setDeadline(DEFAULT_DEADLINE)
         .setTraceServiceEndpoint(TraceServiceStubSettings.getDefaultEndpoint())
@@ -231,6 +228,10 @@ public abstract class TraceConfiguration {
      * @return a {@code TraceConfiguration}.
      */
     public TraceConfiguration build() {
+      // If project ID is not set, attempt to get the Default Project ID
+      if (Strings.isNullOrEmpty(getProjectId())) {
+        setProjectId(Strings.nullToEmpty(ServiceOptions.getDefaultProjectId()));
+      }
       // Make a defensive copy of fixed attributes.
       setFixedAttributes(Collections.unmodifiableMap(new LinkedHashMap<>(getFixedAttributes())));
       Preconditions.checkArgument(

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -25,13 +25,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
-
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 
 /** Configurations for {@link TraceExporter}. */
 @AutoValue


### PR DESCRIPTION
Fixes #141 

Lazy loading Project ID in trace configuration prevents crashes when using the exporter-trace with opencensus-shim. 

#### Test Setup
 - Simple Hello world Java app running on spring-boot. 
 - Traces generated were visible in Google Cloud Trace

Initialization code
```java
private static void initializeOTel() {
		try {
			traceExporter = TraceExporter.createWithConfiguration(TraceConfiguration.builder()
					.setProjectId(PROJECT_ID).build()); //
		} catch (IOException e) {
			e.printStackTrace();
		}

		sdkTracerProvider = SdkTracerProvider.builder()
				.setResource(resource)
				.addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build())
				.build();

		openTelemetry = OpenTelemetrySdk.builder()
				.setTracerProvider(sdkTracerProvider)
				.buildAndRegisterGlobal();

		System.out.println("OpenTelemetry initialized Successfully !!!");
}
```
