### PR TITLE
Remove shadow plugin from exporter-trace module

### DIFF
--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-	id 'com.github.johnrengelman.shadow'
-}
 description = 'Cloud Trace Exporter for OpenTelemetry'
 
 dependencies {


### PR DESCRIPTION
Removes shadow plugin since it is not required and not adding any additional benefit. 