### PR TITLE
Relocate dependencies in the generated shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
 		groovyGradle {
 			target '*.gradle' // default target of groovyGradle
 			greclipse()
-			licenseHeaderFile rootProject.file('buildscripts/spotless.license.gradle'), '(plugins|description)'
+			licenseHeaderFile rootProject.file('buildscripts/spotless.license.gradle'), '(import|plugins|description)'
 		}
 	}
 

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
 plugins {
 	id "maven-publish"
 	id "com.github.johnrengelman.shadow"
@@ -48,8 +49,13 @@ shadowJar {
 	mergeServiceFiles()
 }
 
-// Auto relocation for dependencies
+// Auto relocation for all dependencies
 tasks.named('shadowJar') {
+	// Prevent 'conscrypt' from being relocated.
+	// See https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/161#issuecomment-1478831626 for details
+	// Relocating it back to its original location excludes the package from being automatically relocated to the specified prefix
+	relocate new SimpleRelocator("org.conscrypt", "org.conscrypt", new ArrayList<String>(), new ArrayList<String>())
+
 	enableRelocation true
 	relocationPrefix 'shadow'
 }

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -46,7 +46,11 @@ shadowJar {
 	// gradle warns since explicit or implicit dependency on this shadowJar is not declared
 	dependsOn ':shared-resourcemapping:shadowJar'
 	archiveClassifier.set('shaded')
-	mergeServiceFiles()
+	// since we relocate source classes back to their original package, we do not want the SPIs to be re-written for relocated package
+	mergeServiceFiles {
+		exclude "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider"
+		exclude "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"
+	}
 }
 
 // Auto relocation for all dependencies
@@ -55,6 +59,7 @@ tasks.named('shadowJar') {
 	// See https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/161#issuecomment-1478831626 for details
 	// Relocating it back to its original location excludes the package from being automatically relocated to the specified prefix
 	relocate new SimpleRelocator("org.conscrypt", "org.conscrypt", new ArrayList<String>(), new ArrayList<String>())
+	relocate new SimpleRelocator("com.google.cloud.opentelemetry.auto", "com.google.cloud.opentelemetry.auto", new ArrayList<String>(), new ArrayList<String>())
 
 	enableRelocation true
 	relocationPrefix 'shadow'

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -41,10 +41,17 @@ dependencies {
 	}
 }
 
-
 shadowJar {
+	// gradle warns since explicit or implicit dependency on this shadowJar is not declared
+	dependsOn ':shared-resourcemapping:shadowJar'
 	archiveClassifier.set('shaded')
 	mergeServiceFiles()
+}
+
+// Auto relocation for dependencies
+tasks.named('shadowJar') {
+	enableRelocation true
+	relocationPrefix 'shadow'
 }
 
 publishing {


### PR DESCRIPTION
This updates the exporter-auto build config to be able to generate both - shaded and non-shaded versions of the dependency. 

#### Testing
 - `./gradlew build` generates non-shaded version. (slim-JAR)
 - `./gradlew shadowJar` generates uberJar with shaded (relocated) dependencies. 
 - Ran the `autoconf` and `autoinstrument` examples with the updated JARs - both ran successfully. 
        - `autoinstrument` - Traces are being generated; Metrics have a known issue -  #149

#### Notes
 - The maven publish plugin would have to be configured to release both artifacts. [TODO]
 - The conscrypt plugin is intentionally not shaded - see [this comment](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/161#issuecomment-1478831626).
 - The source classes are also erroneously relocated to the shadow prefix, i.e. `com/google/cloud/opentelemetry/auto/*.class` &rarr; `shadow/com/google/cloud/opentelemetry/auto/*.class`
     
     While this is unconventional, it has not caused any issue in running the examples or cause other test failures.
     It could be argued that moving the source classes to a shaded path prevents users from accidentally accessing these 
     classes and could also prevent ambiguity in-case both shaded and non-shaded versions of this dependency end up on 
     the same classpath *(even though this would most likely be an error and should not be done)*.
