### PR TITLE
Improve build time for e2e-test-server

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -18,7 +18,7 @@ steps:
     id: generate-jar
     entrypoint: "gradle"
     timeout: 4m
-    args: ["shadowJar"]
+    args: [":e2e-test-server:build"]
 
   # Zip the generated JAR file
   - name: ubuntu


### PR DESCRIPTION
This is to improve the build-times as 'shadowJar' generates shadowJars for all sub-projects which is expensive and not required here.