### PR TITLE
Update license header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.gradle
+++ b/buildscripts/spotless.license.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.java
+++ b/buildscripts/spotless.license.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/build.gradle
+++ b/detectors/resources/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/EnvVars.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/EnvVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPMetadataConfig.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPMetadataConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/EnvVarMock.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/EnvVarMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/build.gradle
+++ b/e2e-test-server/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/CloudFunctionHandler.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/CloudFunctionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Constants.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubMessageHandler.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubPullServer.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubPullServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubPushServer.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubPushServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubServer.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Request.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Response.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandler.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Server.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoconf/build.gradle
+++ b/examples/autoconf/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoconf/src/main/java/com/google/cloud/opentelemetry/example/autoconf/AutoconfExample.java
+++ b/examples/autoconf/src/main/java/com/google/cloud/opentelemetry/example/autoconf/AutoconfExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoinstrument/src/main/java/com/google/example/CloudTraceLogAttacher.java
+++ b/examples/autoinstrument/src/main/java/com/google/example/CloudTraceLogAttacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoinstrument/src/main/java/com/google/example/GreetingClient.java
+++ b/examples/autoinstrument/src/main/java/com/google/example/GreetingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/autoinstrument/src/main/java/com/google/example/TestMain.java
+++ b/examples/autoinstrument/src/main/java/com/google/example/TestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/metrics/build.gradle
+++ b/examples/metrics/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
+++ b/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/resource/build.gradle
+++ b/examples/resource/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/resource/src/main/java/com/google/cloud/opentelemetry/example/resource/ResourceExample.java
+++ b/examples/resource/src/main/java/com/google/cloud/opentelemetry/example/resource/ResourceExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring/src/main/java/com/google/cloud/opentelemetry/example/spring/GreetingClient.java
+++ b/examples/spring/src/main/java/com/google/cloud/opentelemetry/example/spring/GreetingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring/src/main/java/com/google/cloud/opentelemetry/example/spring/Main.java
+++ b/examples/spring/src/main/java/com/google/cloud/opentelemetry/example/spring/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/trace/build.gradle
+++ b/examples/trace/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/Constants.java
+++ b/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/GoogleCloudMetricExporterFactory.java
+++ b/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/GoogleCloudMetricExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/GoogleCloudSpanExporterFactory.java
+++ b/exporters/auto/src/main/java/com/google/cloud/opentelemetry/auto/GoogleCloudSpanExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/build.gradle
+++ b/exporters/metrics/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/CloudMetricClient.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/CloudMetricClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/CloudMetricClientImpl.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/CloudMetricClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategy.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTimeSeriesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricWithLabels.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricWithLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/NoopMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/NoopMetricExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategyTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricDescriptorStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MockServerStartupException.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MockServerStartupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/CloudTraceClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/InternalTraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/InternalTraceExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/NoopSpanExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/NoopSpanExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/MockCloudTraceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/MockServerStartupException.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/MockServerStartupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceVersionsTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/build.gradle
+++ b/propagators/gcp/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/OneWayXCloudTraceConfigurablePropagatorProvider.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/OneWayXCloudTraceConfigurablePropagatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceConfigurablePropagatorProvider.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceConfigurablePropagatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/resourcemapping/build.gradle
+++ b/shared/resourcemapping/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/GcpResource.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/GcpResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceLabels.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #220 

Contains only the changes introduced from running `./gradlew spotlessApply` after updating the spotless license files.