### PR TITLE
Fix autoconf example

### DIFF
--- a/examples/autoconf/build.gradle
+++ b/examples/autoconf/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 def autoconf_config = [
 	'-Dotel.traces.exporter=google_cloud_trace',
 	'-Dotel.metrics.exporter=google_cloud_monitoring',
+	'-Dotel.java.global-autoconfigure.enabled=true',
 ]
 
 mainClassName = 'com.google.cloud.opentelemetry.example.autoconf.AutoconfExample'

--- a/examples/autoconf/job.yaml
+++ b/examples/autoconf/job.yaml
@@ -11,6 +11,16 @@ spec:
       containers:
         - name: hello-autoconfigure-java
           image: gcr.io/%GOOGLE_CLOUD_PROJECT%/hello-autoconfigure-java:latest
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONTAINER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+
       # Do not restart containers after they exit
       restartPolicy: Never
   # of retries before marking as failed.


### PR DESCRIPTION
The OTel autoconfigure module was missing configuration parameters and the GKE container was missing required environment variables to publish Cloud monitoring metrics.