### PR TITLE
Add required env variables for publishing metrics

### DIFF
--- a/examples/autoinstrument/README.md
+++ b/examples/autoinstrument/README.md
@@ -8,8 +8,8 @@ export GOOGLE_CLOUD_PROJECT={your-project}
 
 ./gradlew :examples-autoinstrument:jib --image="gcr.io/$GOOGLE_CLOUD_PROJECT/hello-autoinstrument-java"
 
-kubectl create deployment hello-autoinstrument-java \
-  --image=gcr.io/$GOOGLE_CLOUD_PROJECT/hello-autoinstrument-java
+sed s/%GOOGLE_CLOUD_PROJECT%/$GOOGLE_CLOUD_PROJECT/g \
+ examples/autoinstrument/deployment.yaml | kubectl apply -f -
 
 kubectl expose deployment  hello-autoinstrument-java --type LoadBalancer --port 80 --target-port 8080
 ```

--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -51,8 +51,6 @@ jib {
 	from.image = 'gcr.io/distroless/java-debian10:11'
 	containerizingMode = 'packaged'
 	container.ports = ["8080"]
-	// required for resource detection in GKE environment
-	container.environment = ["NAMESPACE": "default", "CONTAINER_NAME": "autoinstrument-example"]
 	extraDirectories {
 		paths {
 			path {

--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -51,6 +51,8 @@ jib {
 	from.image = 'gcr.io/distroless/java-debian10:11'
 	containerizingMode = 'packaged'
 	container.ports = ["8080"]
+	// required for resource detection in GKE environment
+	container.environment = ["NAMESPACE": "default", "CONTAINER_NAME": "autoinstrument-example"]
 	extraDirectories {
 		paths {
 			path {

--- a/examples/autoinstrument/deployment.yaml
+++ b/examples/autoinstrument/deployment.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-autoinstrument-java
+  namespace: default
+  labels:
+    app: hello-autoinstrument-java
+spec:
+  selector:
+    matchLabels:
+      app: hello-autoinstrument-java
+  template:
+    metadata:
+      labels:
+        app: hello-autoinstrument-java
+    spec:
+      containers:
+        - name: hello-autoinstrument-java
+          image: gcr.io/%GOOGLE_CLOUD_PROJECT%/hello-autoinstrument-java:latest
+          # required for resource detection in GKE environment
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONTAINER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name


### PR DESCRIPTION
The added environmnet variables are required for resource detection in GKE environment. The absence of these variables cause failure to publish metrics.