### PR TITLE
Spotless yaml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,22 @@ plugins {
 	id 'nebula.release'
 }
 
+// Required with spotless v6+
+// See https://github.com/diffplug/spotless/issues/984 for details
+spotless {
+	predeclareDepsFromBuildscript()
+}
+
+// Need to predeclare every configuration used with spotless
+spotlessPredeclare {
+	java {
+		googleJavaFormat("1.9")
+	}
+	groovyGradle {
+		greclipse()
+	}
+}
+
 // Format the root build too.
 spotless {
 	groovyGradle {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ spotless {
 		greclipse()
 		licenseHeaderFile rootProject.file('buildscripts/spotless.license.gradle'), '(import|pluginManagement)'
 	}
+	yaml {
+		target "*.yaml"
+		licenseHeaderFile rootProject.file('buildscripts/spotless.license.yaml'), '([a-zA-Z]*:)'
+	}
 }
 
 // Configure release mechanism.
@@ -105,6 +109,10 @@ subprojects {
 			target '*.gradle' // default target of groovyGradle
 			greclipse()
 			licenseHeaderFile rootProject.file('buildscripts/spotless.license.gradle'), '(import|plugins|description)'
+		}
+		yaml {
+			target "*.yaml"
+			licenseHeaderFile rootProject.file('buildscripts/spotless.license.yaml'), '([a-zA-Z]*:)'
 		}
 	}
 

--- a/buildscripts/spotless.license.yaml
+++ b/buildscripts/spotless.license.yaml
@@ -1,0 +1,13 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Generate shadowJar for the instrumented test server
   - name: "gradle:8.0.2-jdk11"

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Wait for the image to exist
   - name: "docker"

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Wait for the image to exist
   - name: "docker"

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Wait for the image to exist
   - name: "docker"

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -1,16 +1,16 @@
-# Copyright 2021 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Wait for the image to exist
   - name: "docker"

--- a/cloudbuild-e2e-image.yaml
+++ b/cloudbuild-e2e-image.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # If the image doesn't exist, create a skip file for the next step to know
   - name: "gcr.io/cloud-builders/gcloud"

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
   # Wait for the image to exist
   - name: "docker"

--- a/examples/autoconf/job.yaml
+++ b/examples/autoconf/job.yaml
@@ -1,3 +1,16 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/autoinstrument/deployment.yaml
+++ b/examples/autoinstrument/deployment.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/examples/resource/job.yaml
+++ b/examples/resource/job.yaml
@@ -1,3 +1,16 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@
  */
 pluginManagement {
 	plugins {
-		id "com.diffplug.spotless" version "5.9.0"
+		id "com.diffplug.spotless" version "6.18.0"
 		id 'nebula.release' version '15.2.0'
 		id "com.github.johnrengelman.shadow" version "8.1.1"
 		id 'com.google.cloud.tools.jib' version '3.1.4'


### PR DESCRIPTION
Fixes #226 

 -   Update Gradle spotless plugin.
 - `./gradlew spotlessApply` now works on YAML file. 

#### Testing
 - `./gradlew clean build` successful. 