### PR TITLE
Add script to run example in docker container

### DIFF
--- a/examples/autoinstrument/README.md
+++ b/examples/autoinstrument/README.md
@@ -1,11 +1,37 @@
 # Autoinstrumentation Example
 
-An example spring webapp deployed and instrumented using the OpenTelemetry Java Auto-instrumentation agent deployed to GKE.
+An example spring webapp deployed and instrumented using the OpenTelemetry Java Auto-instrumentation agent.
+
+### Prerequisites
+
+##### Get Google Cloud Credentials on your machine
+
+```shell
+gcloud auth application-default login
+```
+Executing this command will save your application credentials to default path which will depend on the type of machine -
+- Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+- Windows: `%APPDATA%\gcloud\application_default_credentials.json`
+
+**NOTE: This method of authentication is not recommended for production environments.**
+
+Next, export the credentials to `GOOGLE_APPLICATION_CREDENTIALS` environment variable - 
+
+For Linux & MacOS:
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
+```
+
+##### Export the Google Cloud Project ID to `GOOGLE_CLOUD_PROJECT` environment variable:
+
+```shell
+export GOOGLE_CLOUD_PROJECT="my-awesome-gcp-project-id"
+```
+
+## Running in Google Kubernetes Engine
 
 To spin it up on your own GKE cluster, run the following:
 ```bash
-export GOOGLE_CLOUD_PROJECT={your-project}
-
 ./gradlew :examples-autoinstrument:jib --image="gcr.io/$GOOGLE_CLOUD_PROJECT/hello-autoinstrument-java"
 
 sed s/%GOOGLE_CLOUD_PROJECT%/$GOOGLE_CLOUD_PROJECT/g \
@@ -26,3 +52,15 @@ Or, if you'd like to synthesize a parent trace:
 ```bash
 curl -H "traceparent:  00-ff000000000000000000000000000041-ff00000000000041-01" ${cluster_ip}
 ```
+
+## Running locally in a docker container
+
+In case you do not want to spin up your own GKE cluster, but still want telemetry to be published to Google Cloud, you can run the example in a docker container. 
+
+A convenience script has been provided which will run the example in a docker container.
+
+From the root of the repository,
+```shell
+cd examples/autoinstrument && ./run_in_docker.sh
+```
+You can now interact with the sample spring example on **localhost:8080**. The metrics and traces from this example can be viewed in Google Cloud Console.

--- a/examples/autoinstrument/run_in_docker.sh
+++ b/examples/autoinstrument/run_in_docker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+if [[ -z "${GOOGLE_CLOUD_PROJECT}" ]]; then
+  echo "GOOGLE_CLOUD_PROJECT environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS environment variable not set"
+  exit 1
+fi
+echo "ENVIRONMENT VARIABLES VERIFIED"
+
+echo "BUILDING SAMPLE APP IMAGE"
+gradle clean jib --image "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-autoinstrument-java"
+
+
+echo "RUNNING SAMPLE APP ON PORT 8080"
+docker run \
+      --rm \
+      -e "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" \
+      -e "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" \
+      -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro" \
+      -p 8080:8080 \
+      "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-autoinstrument-java"


### PR DESCRIPTION
This just adds a convenience script that allows users to run auto-instrument example in a local docker container instead of running on GKE.