### PR TITLE
Fix timeseries

### DIFF
--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -15,6 +15,12 @@
  */
 package com.google.cloud.opentelemetry.metric;
 
+import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapDistribution;
+import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapInterval;
+import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetric;
+import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetricDescriptor;
+import static com.google.cloud.opentelemetry.metric.ResourceTranslator.mapResource;
+
 import com.google.api.MetricDescriptor;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.monitoring.v3.TypedValue;
@@ -25,19 +31,12 @@ import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapDistribution;
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapInterval;
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetric;
-import static com.google.cloud.opentelemetry.metric.MetricTranslator.mapMetricDescriptor;
-import static com.google.cloud.opentelemetry.metric.ResourceTranslator.mapResource;
 
 /**
  * Builds GCM TimeSeries from each OTEL metric point, creating metric descriptors based on the

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -30,10 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.ProjectName;
-import com.google.monitoring.v3.SpanContext;
 import com.google.monitoring.v3.TimeSeries;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -216,32 +213,7 @@ class InternalMetricExporter implements MetricExporter {
       ProjectName projectName,
       List<TimeSeries> allTimesSeries) {
     List<List<TimeSeries>> batches = Lists.partition(allTimesSeries, MAX_BATCH_SIZE);
-    JsonFormat.TypeRegistry registry =
-        JsonFormat.TypeRegistry.newBuilder().add(SpanContext.getDescriptor()).build();
     for (List<TimeSeries> timeSeries : batches) {
-      timeSeries.forEach(
-          timeSeriesWithMultiplePoints -> {
-            System.out.println(
-                "Got timeSeries with "
-                    + timeSeriesWithMultiplePoints.getPointsList().size()
-                    + " points");
-            //
-            // timeSeriesWithMultiplePoints.getPointsList().forEach(System.out::println);
-            System.out.println("Full TS object: ");
-            try {
-              String log =
-                  JsonFormat.printer()
-                      .usingTypeRegistry(registry)
-                      .omittingInsignificantWhitespace()
-                      .print(timeSeriesWithMultiplePoints);
-              System.out.println(log);
-            } catch (InvalidProtocolBufferException e) {
-              System.out.println(
-                  "Exception occurred while printing protobuf " + e.getLocalizedMessage());
-              e.printStackTrace();
-            }
-            // System.out.println(timeSeriesWithMultiplePoints);
-          });
       metricServiceClient.createTimeSeries(projectName, new ArrayList<>(timeSeries));
     }
   }

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -30,7 +30,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.SpanContext;
 import com.google.monitoring.v3.TimeSeries;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -213,7 +216,32 @@ class InternalMetricExporter implements MetricExporter {
       ProjectName projectName,
       List<TimeSeries> allTimesSeries) {
     List<List<TimeSeries>> batches = Lists.partition(allTimesSeries, MAX_BATCH_SIZE);
+    JsonFormat.TypeRegistry registry =
+        JsonFormat.TypeRegistry.newBuilder().add(SpanContext.getDescriptor()).build();
     for (List<TimeSeries> timeSeries : batches) {
+      timeSeries.forEach(
+          timeSeriesWithMultiplePoints -> {
+            System.out.println(
+                "Got timeSeries with "
+                    + timeSeriesWithMultiplePoints.getPointsList().size()
+                    + " points");
+            //
+            // timeSeriesWithMultiplePoints.getPointsList().forEach(System.out::println);
+            System.out.println("Full TS object: ");
+            try {
+              String log =
+                  JsonFormat.printer()
+                      .usingTypeRegistry(registry)
+                      .omittingInsignificantWhitespace()
+                      .print(timeSeriesWithMultiplePoints);
+              System.out.println(log);
+            } catch (InvalidProtocolBufferException e) {
+              System.out.println(
+                  "Exception occurred while printing protobuf " + e.getLocalizedMessage());
+              e.printStackTrace();
+            }
+            // System.out.println(timeSeriesWithMultiplePoints);
+          });
       metricServiceClient.createTimeSeries(projectName, new ArrayList<>(timeSeries));
     }
   }


### PR DESCRIPTION
Fixes #225 

There were duplicate metric points being pushed in the same timeseries since the same metric was being logged by multiple libraries. 

According to the exporter spec, by default the instrumentation scope and version should be attached as metric labels which would prevent such an issue. This PR attaches the instrumentation scope and version as metrics label so that the metrics are de-duplicated. 