### PR TITLE
Configures auto-exporter to publish shaded and non-shaded variants

### DIFF
--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -66,19 +66,3 @@ tasks.named('shadowJar') {
 	enableRelocation true
 	relocationPrefix 'shadow'
 }
-
-publishing {
-	publications {
-		maven(MavenPublication) { publication ->
-			from components.java
-		}
-		shadow(MavenPublication) { publication ->
-			from project.shadow.component(publication)
-			artifact sourcesJar
-			artifact javadocJar
-			components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
-				skip()
-			}
-		}
-	}
-}

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -70,6 +70,9 @@ tasks.named('shadowJar') {
 publishing {
 	publications {
 		maven(MavenPublication) { publication ->
+			from components.java
+		}
+		shadow(MavenPublication) { publication ->
 			from project.shadow.component(publication)
 			artifact sourcesJar
 			artifact javadocJar

--- a/exporters/auto/gradle.properties
+++ b/exporters/auto/gradle.properties
@@ -1,3 +1,2 @@
 release.qualifier=alpha
 release.enabled=true
-shadowed=true


### PR DESCRIPTION
Supports #215 

Currently, if `gradle.properties` have `shadowed` property set to true, then only shadowed variant is published, this change also configures the maven-publish plugin to publish normal Jar along with the shadow-jar. 

The `artifactId` is currently set to be the `archivesBaseName` which based on current configuration for auto-exporter should contain the suffix - `shaded`.

#### Testing
 - Ran `./gradlew clean build`
 - Ran `./gradlew publishToMavenLocal` & verified that the `.m2` repository contained both - shaded and non-shaded JARs.
 
 ### Generated artifacts through local publish 
Below is the tree structure of the generated artifacts (from local `.m2` repo)
 ```
 exporter-auto/
├── 0.1.0-alpha-SNAPSHOT
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT.jar
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT-javadoc.jar
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT.module
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT.pom
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT-shaded.jar
│   ├── exporter-auto-0.1.0-alpha-SNAPSHOT-sources.jar
│   └── maven-metadata-local.xml
└── maven-metadata-local.xml
 ```
 
 #### JAR contents for sources JAR - 
 `jar tf exporter-auto-0.1.0-alpha-SNAPSHOT-sources.jar`

```
META-INF/
META-INF/MANIFEST.MF
com/
com/google/
com/google/cloud/
com/google/cloud/opentelemetry/
com/google/cloud/opentelemetry/auto/
com/google/cloud/opentelemetry/auto/GoogleCloudMetricExporterFactory.java
com/google/cloud/opentelemetry/auto/Constants.java
com/google/cloud/opentelemetry/auto/GoogleCloudSpanExporterFactory.java
```

Verified that the sources and javadoc JARs are for the un-shaded variant. 