### PR TITLE
Adds dependency declarations to order tasks

### DIFF
--- a/exporters/metrics/build.gradle
+++ b/exporters/metrics/build.gradle
@@ -34,3 +34,5 @@ dependencies {
 	testImplementation(testLibraries.opentelemetry_sdk_testing)
 	testImplementation(testLibraries.opencensus_shim)
 }
+
+test.dependsOn ':shared-resourcemapping:shadowJar'

--- a/exporters/trace/build.gradle
+++ b/exporters/trace/build.gradle
@@ -51,3 +51,5 @@ task generateVersionResource {
 		propertiesFile.write("exporter.version=${project.version}")
 	}
 }
+
+test.dependsOn ':shared-resourcemapping:shadowJar'

--- a/shared/resourcemapping/build.gradle
+++ b/shared/resourcemapping/build.gradle
@@ -56,3 +56,6 @@ publishing {
 		}
 	}
 }
+
+// This is to fix the explicit dependency error which comes when publishing via the `candidate` task
+publishMavenPublicationToMavenRepository.dependsOn jar


### PR DESCRIPTION
The missing dependency declarations result in errors in the release tasks - pointing to possibility of incorrect result depending on order in which these tasks execute.
The release tasks are skipped during normal :build jobs so build passes, but the artifacts snapshot generation for release fails.

Supports #215 