### PR TITLE
Declares explicit dependency for signMavenPublication

### DIFF
--- a/shared/resourcemapping/build.gradle
+++ b/shared/resourcemapping/build.gradle
@@ -59,3 +59,4 @@ publishing {
 
 // This is to fix the explicit dependency error which comes when publishing via the `candidate` task
 publishMavenPublicationToMavenRepository.dependsOn jar
+signMavenPublication.dependsOn jar


### PR DESCRIPTION
Adds missing dependency declaration for task `signMavenPublication` for shared-resourcemapping module. 


#### Testing
 - Verified `./gradlew clean build`
 - Verified `./gradlew snapshot` - is now passing ✅ 