### PR TITLE
Adds explicit instruction for shaded release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,9 @@ subprojects {
 					groupId = 'com.google.cloud.opentelemetry'
 					afterEvaluate {
 						artifactId = archivesBaseName
+						if (findProperty("shadow.release") != null) {
+							artifactId = artifactId + "-shaded"
+						}
 						if (findProperty("release.qualifier") != null) {
 							String[] versionParts = version.split('-')
 							versionParts[0] = "${versionParts[0]}-${findProperty("release.qualifier")}"

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -66,3 +66,11 @@ tasks.named('shadowJar') {
 	enableRelocation true
 	relocationPrefix 'shadow'
 }
+
+publishing {
+	publications {
+		shadow(MavenPublication) { publication ->
+			project.shadow.component(publication)
+		}
+	}
+}

--- a/exporters/auto/gradle.properties
+++ b/exporters/auto/gradle.properties
@@ -1,2 +1,4 @@
 release.qualifier=alpha
 release.enabled=true
+# Releases a shadowed variant of the artifact with '-shaded' as artifactId suffix
+shadow.release=true


### PR DESCRIPTION
Since the artifact Id of the shaded and non-shaded variants were not separated, the maven-publish plugin seemed to release only a single artifact for non-shaded variant (even though the shaded-jar was available for download from browse section). 

This fix should create 2 separate artifacts - `exporter-auto` & `exporter-auto-shaded`.