### PR TITLE
Revert "Adds explicit instruction for shaded release"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,9 +248,6 @@ subprojects {
 					groupId = 'com.google.cloud.opentelemetry'
 					afterEvaluate {
 						artifactId = archivesBaseName
-						if (findProperty("shadow.release") != null) {
-							artifactId = artifactId + "-shaded"
-						}
 						if (findProperty("release.qualifier") != null) {
 							String[] versionParts = version.split('-')
 							versionParts[0] = "${versionParts[0]}-${findProperty("release.qualifier")}"

--- a/exporters/auto/build.gradle
+++ b/exporters/auto/build.gradle
@@ -66,11 +66,3 @@ tasks.named('shadowJar') {
 	enableRelocation true
 	relocationPrefix 'shadow'
 }
-
-publishing {
-	publications {
-		shadow(MavenPublication) { publication ->
-			project.shadow.component(publication)
-		}
-	}
-}

--- a/exporters/auto/gradle.properties
+++ b/exporters/auto/gradle.properties
@@ -1,4 +1,2 @@
 release.qualifier=alpha
 release.enabled=true
-# Releases a shadowed variant of the artifact with '-shaded' as artifactId suffix
-shadow.release=true


### PR DESCRIPTION
Reverts GoogleCloudPlatform/opentelemetry-operations-java#240

We do not want shaded version in a different artifact - use classifiers instead. 