### PR TITLE
Fixes broken pom by removing versionMapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,11 +254,6 @@ subprojects {
 							version = versionParts.join("-")
 						}
 					}
-					versionMapping {
-						allVariants {
-							fromResolutionResult()
-						}
-					}
 					pom {
 						name = 'OpenTelemetry Operations Java'
 						url = 'https://github.com/GoogleCloudPlatform/opentelemetry-operations-java'


### PR DESCRIPTION
This makes sure that the POM generated for `exporter-auto` has correct dependency versions. The current POM is broken, which makes the non-shaded variant difficult to use. 

We use release qualifiers which are appended to the version names, these qualifiers seem to be stripped away during versionMapping phase - [v0.25.0-alpha POM](https://search.maven.org/artifact/com.google.cloud.opentelemetry/exporter-auto/0.25.0-alpha/jar). 

The new generated POM - *from the staging sonatype repository*

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
  <!--  This module was also published with a richer model, Gradle metadata,   -->
  <!--  which should be used instead. Do not delete the following line which   -->
  <!--  is to indicate to Gradle or any Gradle module metadata file consumer   -->
  <!--  that they should prefer consuming it instead.  -->
  <!--  do_not_remove: published-with-gradle-metadata  -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.google.cloud.opentelemetry</groupId>
  <artifactId>exporter-auto</artifactId>
  <version>0.25.1-alpha</version>
  <name>OpenTelemetry Operations Java</name>
  <description>Auto Exporter for OpenTelemetry</description>
  <url>https://github.com/GoogleCloudPlatform/opentelemetry-operations-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>com.google.cloud.opentelemetry</id>
      <name>OpenTelemetry Operations Contributors</name>
      <email>opentelemetry-team@google.com</email>
      <organization>Google Inc</organization>
      <organizationUrl>https://cloud.google.com/products/operations</organizationUrl>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java</connection>
    <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/opentelemetry-operations-java</developerConnection>
    <url>https://github.com/GoogleCloudPlatform/opentelemetry-operations-java</url>
  </scm>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>com.google.cloud</groupId>
        <artifactId>libraries-bom</artifactId>
        <version>26.11.0</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>io.opentelemetry</groupId>
        <artifactId>opentelemetry-bom</artifactId>
        <version>1.24.0</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>com.google.auto.service</groupId>
      <artifactId>auto-service-annotations</artifactId>
      <version>1.0.1</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.auto.value</groupId>
      <artifactId>auto-value-annotations</artifactId>
      <version>1.10.1</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.cloud.opentelemetry</groupId>
      <artifactId>exporter-metrics</artifactId>
      <version>0.25.1</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>io.opentelemetry</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>com.google.cloud.opentelemetry</groupId>
      <artifactId>exporter-trace</artifactId>
      <version>0.25.1</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>io.opentelemetry</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>com.google.cloud.opentelemetry</groupId>
      <artifactId>detector-resources</artifactId>
      <!-- The release qualifier 'alpha' was not removed because of version mapping -->
      <version>0.25.1-alpha</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>io.opentelemetry</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>com.google.cloud.opentelemetry</groupId>
      <artifactId>propagators-gcp</artifactId>
      <!-- The release qualifier 'alpha' was not removed because of version mapping -->
      <version>0.25.1-alpha</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>io.opentelemetry</groupId>
        </exclusion>
      </exclusions>
    </dependency>
  </dependencies>
</project>
```
The version names for `propagators-gcp` and `detector-resources` now have correct version numbers (they include alpha). 

### Testing
 - Created a staging repository on sonatype to confirm the contents of the published artifacts. The POMs now seem to have the correct dependency versions. 
