### PR TITLE
Enable metrics-exporter example to run as cloud run job

### DIFF
--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -25,12 +25,31 @@ export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_c
 export GOOGLE_CLOUD_PROJECT="my-awesome-gcp-project-id"
 ```
 
-#### Run the example
+### Running the example
+
+#### Run the example locally
 
 You can run the example application via gradle. From the project root:
 
 ```shell
 cd examples/metrics/ && gradle run 
+```
+
+#### Run the example as a Cloud Run Job
+
+You can run the example application as a Google Cloud Run Job. A convenience script has been provided for this.
+
+First, export your preferred Google cloud region where you want to create and run the job:
+
+```shell
+# This can be any valid Google Cloud Region
+export GOOGLE_CLOUD_RUN_JOB_REGION="us-central1"
+```
+
+Then, from the project root:
+
+```shell
+cd examples/metrics/ && ./run_as_cloud-run-job.sh
 ```
 
 You should now see the exported metrics in your Google Cloud project.

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -52,4 +52,7 @@ Then, from the project root:
 cd examples/metrics/ && ./run_as_cloud-run-job.sh
 ```
 
+*Note: When using the convenience script, it will create a Google Cloud Artifact Registry named `cloud-run-applications` in your
+selected project.*
+
 You should now see the exported metrics in your Google Cloud project.

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -1,0 +1,36 @@
+### Running the example to export metrics to Google Cloud
+
+You can run this example to generate sample metrics on any Google Cloud project.
+
+#### Prerequisites
+
+##### Get Google Cloud Credentials on your machine
+
+```shell
+gcloud auth application-default login
+```
+Executing this command will save your application credentials to default path which will depend on the type of machine -
+- Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+- Windows: `%APPDATA%\gcloud\application_default_credentials.json`
+
+##### Export the retrieved credentials to `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
+```
+
+##### Export the Google Cloud Project ID to `GOOGLE_CLOUD_PROJECT` environment variable:
+
+```shell
+export GOOGLE_CLOUD_PROJECT="my-awesome-gcp-project-id"
+```
+
+#### Run the example
+
+You can run the example application via gradle. From the project root:
+
+```shell
+cd examples/metrics/ && gradle run 
+```
+
+You should now see the exported metrics in your Google Cloud project.

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -43,7 +43,7 @@ First, export your preferred Google cloud region where you want to create and ru
 
 ```shell
 # This can be any valid Google Cloud Region
-export GOOGLE_CLOUD_RUN_JOB_REGION="us-central1"
+export GOOGLE_CLOUD_RUN_REGION="us-central1"
 ```
 
 Then, from the project root:

--- a/examples/metrics/run_as_cloud-run-job.sh
+++ b/examples/metrics/run_as_cloud-run-job.sh
@@ -27,8 +27,8 @@ if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   exit 1
 fi
 
-if [[ -z "${GOOGLE_CLOUD_RUN_JOB_REGION}" ]]; then
-  echo "GOOGLE_CLOUD_RUN_JOB_REGION environment variable not set"
+if [[ -z "${GOOGLE_CLOUD_RUN_REGION}" ]]; then
+  echo "GOOGLE_CLOUD_RUN_REGION environment variable not set"
   exit 1
 fi
 
@@ -45,11 +45,11 @@ echo "CREATING A CLOUD RUN JOB TO RUN THE CONTAINER"
 gcloud run jobs create job-metrics-export \
     --image "${REGISTRY_LOCATION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/${CONTAINER_REGISTRY}/metrics-export-java" \
     --max-retries 5 \
-    --region ${GOOGLE_CLOUD_RUN_JOB_REGION} \
+    --region ${GOOGLE_CLOUD_RUN_REGION} \
     --project="${GOOGLE_CLOUD_PROJECT}"
 
 echo "SETTING CLOUD RUN JOB REGION"
-gcloud config set run/region "${GOOGLE_CLOUD_RUN_JOB_REGION}"
+gcloud config set run/region "${GOOGLE_CLOUD_RUN_REGION}"
 
 echo "RUNNING THE CREATED JOB"
 gcloud run jobs execute job-metrics-export

--- a/examples/metrics/run_as_cloud-run-job.sh
+++ b/examples/metrics/run_as_cloud-run-job.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+if [[ -z "${GOOGLE_CLOUD_PROJECT}" ]]; then
+  echo "GOOGLE_CLOUD_PROJECT environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${GOOGLE_CLOUD_RUN_JOB_REGION}" ]]; then
+  echo "GOOGLE_CLOUD_RUN_JOB_REGION environment variable not set"
+  exit 1
+fi
+
+echo "ENVIRONMENT VARIABLES VERIFIED"
+
+echo "BUILDING SAMPLE APP IMAGE"
+gradle clean jib --image "gcr.io/${GOOGLE_CLOUD_PROJECT}/metrics-export-java"
+
+
+echo "CREATING A CLOUD RUN JOB TO RUN THE CONTAINER"
+gcloud run jobs create job-metrics-export \
+    --image "gcr.io/${GOOGLE_CLOUD_PROJECT}/metrics-export-java" \
+    --max-retries 5 \
+    --region ${GOOGLE_CLOUD_RUN_JOB_REGION} \
+    --project="${GOOGLE_CLOUD_PROJECT}"
+
+echo "SETTING CLOUD RUN JOB REGION"
+gcloud config set run/region "${GOOGLE_CLOUD_RUN_JOB_REGION}"
+
+echo "RUNNING THE CREATED JOB"
+gcloud run jobs execute job-metrics-export


### PR DESCRIPTION
Enhances the example by adding a README and by providing a convenience script to run the example as a cloud-run-job. 