### PR TITLE
Hardcode path separator used for metric type

### DIFF
--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
@@ -38,7 +38,6 @@ import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.data.SumData;
-import java.nio.file.Paths;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -226,7 +225,7 @@ public final class MetricTranslator {
         return instrumentName;
       }
     }
-    return Paths.get(prefix, instrumentName).toString();
+    return String.join("/", prefix, instrumentName);
   }
 
   private static Distribution.Exemplar mapExemplar(ExemplarData exemplar, String projectId) {


### PR DESCRIPTION
### Description
Using Java Paths class to combine string leads to different path-separators depending on the OS of the machine code runs on. For metric names, only the linux path-separators are valid, so hardcoding this.

### Testing
 - Tested this change on a windows machine by running the [metrics example](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/examples/metrics) and ensuring that exported metrics appear in GCP.

### Issues
 - Fix #252 