### PR TITLE
Update copyright from "Google" -> "Google LLC"

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -4,5 +4,6 @@ sourceFileExtensions:
   - gradle
   - java
   - sh
+  - Dockerfile
 allowedCopyrightHolders:
   - Google LLC

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ spotless {
 		target "*.yaml"
 		licenseHeaderFile rootProject.file('buildscripts/spotless.license.yaml'), '([a-zA-Z]*:)'
 	}
-	format 'misc', {
+	format 'dockerfile', {
 		target '*Dockerfile'
 		licenseHeaderFile rootProject.file('buildscripts/spotless.license.dockerfile'), '(\\s+|FROM)'
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ spotless {
 		target "*.yaml"
 		licenseHeaderFile rootProject.file('buildscripts/spotless.license.yaml'), '([a-zA-Z]*:)'
 	}
+	format 'misc', {
+		target '*Dockerfile'
+		licenseHeaderFile rootProject.file('buildscripts/spotless.license.dockerfile'), '(\\s+|FROM)'
+	}
 }
 
 // Configure release mechanism.

--- a/buildscripts/spotless.license.dockerfile
+++ b/buildscripts/spotless.license.dockerfile
@@ -11,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Build relative to root of repository i.e. `docker build --file e2e.Dockerfile --tag=$tag ..`
-FROM gradle:8.0.2-jdk11 as builder
-
-COPY --chown=gradle:gradle . /app/src
-WORKDIR /app/src
-RUN gradle :e2e-test-server:build
-
-FROM openjdk:11-jre-slim
-COPY --from=builder /app/src/e2e-test-server/build/libs/*-all.jar /app/app.jar
-WORKDIR /app
-CMD java -jar app.jar

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -1,5 +1,5 @@
 
-# Copyright 2021 Google
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/144. This was mostly done in #230 but one got through.

Ran
```sh
perl -i -pe 's/Copyright (\d+) Google$/Copyright $1 Google LLC/g' $(git ls-files)
```