### PR TITLE
upgrade google java format for jdk 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ spotless {
 // Need to predeclare every configuration used with spotless
 spotlessPredeclare {
 	java {
-		googleJavaFormat("1.9")
+		googleJavaFormat("1.10.0")
 	}
 	groovyGradle {
 		greclipse()
@@ -106,7 +106,7 @@ subprojects {
 	// Include license check and auto-format support.
 	spotless {
 		java {
-			googleJavaFormat("1.9")
+			googleJavaFormat("1.10.0")
 			licenseHeaderFile rootProject.file('buildscripts/spotless.license.java'), '(package|import|class|// Includes work from:)'
 		}
 		groovyGradle {


### PR DESCRIPTION
When trying to build the project with JDK 17 and `gradle assemble`, I get the following error message:

```
> You are running Spotless on JVM 17. This requires google-java-format of at least 1.10.0 (you are using 1.9).
```

Just upgrading the google java format to the next version as instructed works.