### PR TITLE
Update OTel dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,29 +135,33 @@ subprojects {
 
 	ext {
 		assertjVersion = '3.22.0'
-		autoServiceVersion = '1.0.1'
-		autoValueVersion = '1.10.1'
-		slf4jVersion = '2.0.7'
-		googleCloudVersion = '2.14.0'
-		googleTraceVersion = '2.14.0'
-		googleCloudBom = '26.11.0'
-		cloudMonitoringVersion = '3.15.0'
-		openTelemetryBom = '1.24.0'
-		openTelemetryVersion = '1.24.0'
-		openTelemetryInstrumentationVersion = '1.24.0'
+		autoServiceVersion = '1.1.1'
+		autoValueVersion = '1.10.4'
+		slf4jVersion = '2.0.9'
+		googleCloudVersion = '2.27.0'
+		googleTraceVersion = '2.30.0'
+		googleCloudBom = '26.26.0'
+		cloudMonitoringVersion = '3.31.0'
+		openTelemetryBom = '1.31.0'
+		openTelemetryVersion = '1.31.0'
+		openTelemetryInstrumentationVersion = '1.31.0'
 		openTelemetrySdkExtensionResourceVersion = '1.19.0'
+		openTelemetrySemconvVersion = '1.22.0'
 		junitVersion = '4.13'
 		mockitoVersion = '3.5.10'
-		pubSubVersion = '1.123.7'
+		pubSubVersion = '1.125.11'
 		testContainersVersion = '1.15.1'
 		wiremockVersion = '2.27.2'
 		springWebVersion = '2.4.5'
 		springOpenFeignVersion = '3.0.0'
 		springOtelVersion = '1.0.0-M8'
-		cloudEventsCoreVersion = '2.4.0'
+		cloudEventsCoreVersion = '2.5.0'
 		cloudFunctionsFrameworkApiVersion = '1.0.4'
 		opencensusShimVersion = '1.23.1'
 
+		agentLibraries = [
+			agent: "io.opentelemetry.javaagent:opentelemetry-javaagent:${openTelemetryInstrumentationVersion}",
+		]
 		libraries = [
 			auto_service_annotations         : "com.google.auto.service:auto-service-annotations:${autoServiceVersion}",
 			auto_service                     : "com.google.auto.service:auto-service:${autoServiceVersion}",
@@ -179,18 +183,15 @@ subprojects {
 			opentelemetry_sdk                : "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
 			opentelemetry_sdk_common         : "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}",
 			opentelemetry_autoconfigure_spi  : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${openTelemetryVersion}",
-			opentelemetry_semconv            : "io.opentelemetry:opentelemetry-semconv:${openTelemetryVersion}-alpha",
+			opentelemetry_semconv            : "io.opentelemetry.semconv:opentelemetry-semconv:${openTelemetrySemconvVersion}-alpha",
 			opentelemetry_sdk_metrics        : "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}",
-			opentelemetry_sdk_autoconf       : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}-alpha",
+			opentelemetry_sdk_autoconf       : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}",
 			opentelemetry_sdk_resources      : "io.opentelemetry:opentelemetry-sdk-extension-resources:${openTelemetrySdkExtensionResourceVersion}",
 			opentelemetry_agent_extension    : "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${openTelemetryInstrumentationVersion}-alpha",
 			opentelemetry_otlp_exporter      : "io.opentelemetry:opentelemetry-exporter-otlp:${openTelemetryVersion}",
 			spring_boot_starter_web          : "org.springframework.boot:spring-boot-starter-web:${springWebVersion}",
 			spring_cloud_starter_openfeign   : "org.springframework.cloud:spring-cloud-starter-openfeign:${springOpenFeignVersion}",
 			spring_cloud_sleuth_otel_autoconf: "org.springframework.cloud:spring-cloud-sleuth-otel-autoconfigure:${springOtelVersion}",
-		]
-		agentLibraries = [
-			agent: "io.opentelemetry.javaagent:opentelemetry-javaagent:${openTelemetryInstrumentationVersion}",
 		]
 		testLibraries = [
 			assertj : "org.assertj:assertj-core:${assertjVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,6 @@ subprojects {
 		openTelemetryBom = '1.31.0'
 		openTelemetryVersion = '1.31.0'
 		openTelemetryInstrumentationVersion = '1.31.0'
-		openTelemetrySdkExtensionResourceVersion = '1.19.0'
 		openTelemetrySemconvVersion = '1.22.0'
 		junitVersion = '4.13'
 		mockitoVersion = '3.5.10'
@@ -182,11 +181,10 @@ subprojects {
 			opentelemetry_context            : "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}",
 			opentelemetry_sdk                : "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}",
 			opentelemetry_sdk_common         : "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}",
-			opentelemetry_autoconfigure_spi  : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${openTelemetryVersion}",
 			opentelemetry_semconv            : "io.opentelemetry.semconv:opentelemetry-semconv:${openTelemetrySemconvVersion}-alpha",
 			opentelemetry_sdk_metrics        : "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}",
 			opentelemetry_sdk_autoconf       : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}",
-			opentelemetry_sdk_resources      : "io.opentelemetry:opentelemetry-sdk-extension-resources:${openTelemetrySdkExtensionResourceVersion}",
+			opentelemetry_autoconfigure_spi  : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${openTelemetryVersion}",
 			opentelemetry_agent_extension    : "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${openTelemetryInstrumentationVersion}-alpha",
 			opentelemetry_otlp_exporter      : "io.opentelemetry:opentelemetry-exporter-otlp:${openTelemetryVersion}",
 			spring_boot_starter_web          : "org.springframework.boot:spring-boot-starter-web:${springWebVersion}",

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
@@ -16,7 +16,7 @@
 package com.google.cloud.opentelemetry.detectors;
 
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 
 /**
  * A utility class that contains method that facilitate extraction of attributes from environment

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
@@ -21,7 +21,7 @@ import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.logging.Logger;
 
 /**

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
@@ -15,25 +15,26 @@
  */
 package com.google.cloud.opentelemetry.detectors;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.ServiceLoader;
+import io.opentelemetry.semconv.ResourceAttributes;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class GCPResourceTest {

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
@@ -15,26 +15,25 @@
  */
 package com.google.cloud.opentelemetry.detectors;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
-import io.opentelemetry.semconv.ResourceAttributes;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.ServiceLoader;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.semconv.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class GCPResourceTest {

--- a/e2e-test-server/build.gradle
+++ b/e2e-test-server/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	implementation platform(libraries.opentelemetry_bom)
 	implementation project(':exporter-trace')
 	implementation project(':propagators-gcp')
-	runtimeOnly project(':detector-resources')
+	implementation project(':detector-resources')
 }
 
 tasks.build.dependsOn tasks.shadowJar

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -28,7 +28,8 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -84,15 +85,10 @@ public class ScenarioHandlerManager {
   /** Test where we include resource detection */
   private Response detectResource(Request request) {
     LOGGER.info("Running detectResource test, request: " + request);
-    // TODO - this may fail to just pull the resource.
     Resource resource =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .addPropertiesSupplier(
-                () -> Map.of("otel.traces.exporter", "none", "otel.metrics.exporter", "none"))
-            .registerShutdownHook(false)
-            .build()
-            .getResource();
+        ResourceConfiguration.createEnvironmentResource(
+            DefaultConfigProperties.create(
+                Map.of("otel.traces.exporter", "none", "otel.metrics.exporter", "none")));
     return withTemporaryOtel(
         resource,
         (sdk) -> {

--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.opentelemetry.endtoend;
 
+import com.google.cloud.opentelemetry.detectors.GCPResource;
 import com.google.cloud.opentelemetry.propagators.XCloudTraceContextPropagator;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
@@ -40,6 +41,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
@@ -66,7 +68,7 @@ public class ScenarioHandlerManager {
 
   /** Basic trace test. */
   private Response basicTrace(Request request) {
-    LOGGER.info("Running basicTrace test, request: " + request);
+    LOGGER.info("Running basicTrace test, request: " + request.toString());
     return withTemporaryTracer(
         (tracer) -> {
           Span span =
@@ -75,6 +77,7 @@ public class ScenarioHandlerManager {
                   .setAttribute(Constants.TEST_ID, request.testId())
                   .startSpan();
           try {
+            LOGGER.info("Sending trace with ID: " + span.getSpanContext().getTraceId());
             return Response.ok(Map.of(Constants.TRACE_ID, span.getSpanContext().getTraceId()));
           } finally {
             span.end();
@@ -84,11 +87,17 @@ public class ScenarioHandlerManager {
 
   /** Test where we include resource detection */
   private Response detectResource(Request request) {
-    LOGGER.info("Running detectResource test, request: " + request);
+    LOGGER.info("Running detectResource test, request: " + request.toString());
+    Resource gcpResource =
+        new GCPResource()
+            .createResource(
+                DefaultConfigProperties.create(
+                    Map.of("otel.traces.exporter", "none", "otel.metrics.exporter", "none")));
     Resource resource =
-        ResourceConfiguration.createEnvironmentResource(
-            DefaultConfigProperties.create(
-                Map.of("otel.traces.exporter", "none", "otel.metrics.exporter", "none")));
+        Resource.getDefault()
+            .merge(gcpResource)
+            .merge(ResourceConfiguration.createEnvironmentResource());
+
     return withTemporaryOtel(
         resource,
         (sdk) -> {
@@ -210,7 +219,7 @@ public class ScenarioHandlerManager {
     TraceConfiguration configuration =
         TraceConfiguration.builder()
             .setDeadline(Duration.ofMillis(30000))
-            .setProjectId(Constants.PROJECT_ID != "" ? Constants.PROJECT_ID : null)
+            .setProjectId(!Objects.equals(Constants.PROJECT_ID, "") ? Constants.PROJECT_ID : null)
             .build();
 
     SpanExporter traceExporter = TraceExporter.createWithConfiguration(configuration);

--- a/examples/resource/build.gradle
+++ b/examples/resource/build.gradle
@@ -25,7 +25,6 @@ description = 'Examples for showing resource detection in various GCP environmen
 dependencies {
 	implementation project(':detector-resources')
 	implementation(libraries.opentelemetry_sdk_autoconf)
-	implementation(libraries.opentelemetry_sdk_resources)
 	implementation(libraries.opentelemetry_otlp_exporter)
 }
 

--- a/examples/resource/src/main/java/com/google/cloud/opentelemetry/example/resource/ResourceExample.java
+++ b/examples/resource/src/main/java/com/google/cloud/opentelemetry/example/resource/ResourceExample.java
@@ -16,17 +16,13 @@
 package com.google.cloud.opentelemetry.example.resource;
 
 import com.google.cloud.opentelemetry.detectors.GCPResource;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
+import io.opentelemetry.sdk.resources.Resource;
 
 public class ResourceExample {
   public static void main(String[] args) {
     System.out.println("Detecting resource: Autoconfigure");
-    io.opentelemetry.sdk.resources.Resource autoResource =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .setServiceClassLoader(ResourceExample.class.getClassLoader())
-            .build()
-            .getResource();
+    Resource autoResource = ResourceConfiguration.createEnvironmentResource();
     System.out.println(autoResource.getAttributes());
     System.out.println("Detecting resource: hardcoded");
     GCPResource resource = new GCPResource();

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -42,7 +42,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceVersions.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.opentelemetry.trace;
 
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.TELEMETRY_SDK_VERSION;
-// import static
-// io.opentelemetry.semconv.resource.attributes.ResourceAttributes.TELEMETRY_SDK_VERSION;
+import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_VERSION;
 
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Properties;

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceTranslatorTest.java
@@ -35,7 +35,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/AutoConfigureTest.java
@@ -61,8 +61,7 @@ public class AutoConfigureTest {
   private static ContextPropagators findsWithAutoConfigure(String propagator) {
     AutoConfiguredOpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .registerShutdownHook(false)
+            .disableShutdownHook()
             .addPropertiesSupplier(
                 () ->
                     Map.of(
@@ -71,6 +70,8 @@ public class AutoConfigureTest {
                         "otel.traces.exporter",
                         "none",
                         "otel.metrics.exporter",
+                        "none",
+                        "otel.logs.exporter",
                         "none"))
             .build();
     return sdk.getOpenTelemetrySdk().getPropagators();

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -17,7 +17,7 @@ package com.google.cloud.opentelemetry.resource;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -21,7 +21,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;


### PR DESCRIPTION
There were breaking changes introduced in the latest upstream OTel [releases](https://github.com/open-telemetry/opentelemetry-java/releases), causing the latest auto-instrumentation agent to be incompatible with GCP exporters.

This PR addresses those breaking changes.

fixes #263 