### PR TITLE
Revert "Use faas.instance instead of faas.id in resource detection and mapping (#260)

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -44,5 +44,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/AttributesExtractorUtil.java
@@ -114,7 +114,7 @@ public class AttributesExtractorUtil {
    *
    * <ul>
    *   <li>If the instance ID cannot be found, calling this method has no effect.
-   *   <li>Calling this method will update {@link ResourceAttributes#FAAS_INSTANCE} attribute.
+   *   <li>Calling this method will update {@link ResourceAttributes#FAAS_ID} attribute.
    * </ul>
    *
    * @param attributesBuilder The {@link AttributesBuilder} to which the extracted property needs to
@@ -126,7 +126,7 @@ public class AttributesExtractorUtil {
       AttributesBuilder attributesBuilder, GCPMetadataConfig metadataConfig) {
     String instanceId = metadataConfig.getInstanceId();
     if (instanceId != null) {
-      attributesBuilder.put(ResourceAttributes.FAAS_INSTANCE, instanceId);
+      attributesBuilder.put(ResourceAttributes.FAAS_ID, instanceId);
     }
   }
 }

--- a/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
+++ b/detectors/resources/src/main/java/com/google/cloud/opentelemetry/detectors/GCPResource.java
@@ -286,7 +286,7 @@ public class GCPResource implements ResourceProvider {
 
       String appInstanceId = envVars.get("GAE_INSTANCE");
       if (appInstanceId != null) {
-        attrBuilder.put(ResourceAttributes.FAAS_INSTANCE, appInstanceId);
+        attrBuilder.put(ResourceAttributes.FAAS_ID, appInstanceId);
       }
       updateAttributesWithRegion(attrBuilder);
       AttributesExtractorUtil.addAvailabilityZoneFromMetadata(attrBuilder, metadata);

--- a/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
+++ b/detectors/resources/src/test/java/com/google/cloud/opentelemetry/detectors/GCPResourceTest.java
@@ -184,7 +184,7 @@ public class GCPResourceTest {
         .containsEntry(ResourceAttributes.CLOUD_REGION, "country-region")
         .containsEntry(ResourceAttributes.FAAS_NAME, envVars.get("K_SERVICE"))
         .containsEntry(ResourceAttributes.FAAS_VERSION, envVars.get("K_REVISION"))
-        .containsEntry(ResourceAttributes.FAAS_INSTANCE, "GCF-instance-id");
+        .containsEntry(ResourceAttributes.FAAS_ID, "GCF-instance-id");
   }
 
   /** Google App Engine Tests * */
@@ -212,7 +212,7 @@ public class GCPResourceTest {
         .containsEntry(ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone")
         .containsEntry(ResourceAttributes.FAAS_NAME, envVars.get("GAE_SERVICE"))
         .containsEntry(ResourceAttributes.FAAS_VERSION, envVars.get("GAE_VERSION"))
-        .containsEntry(ResourceAttributes.FAAS_INSTANCE, envVars.get("GAE_INSTANCE"));
+        .containsEntry(ResourceAttributes.FAAS_ID, envVars.get("GAE_INSTANCE"));
   }
 
   @Test
@@ -241,7 +241,7 @@ public class GCPResourceTest {
         .containsEntry(ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone")
         .containsEntry(ResourceAttributes.FAAS_NAME, envVars.get("GAE_SERVICE"))
         .containsEntry(ResourceAttributes.FAAS_VERSION, envVars.get("GAE_VERSION"))
-        .containsEntry(ResourceAttributes.FAAS_INSTANCE, envVars.get("GAE_INSTANCE"));
+        .containsEntry(ResourceAttributes.FAAS_ID, envVars.get("GAE_INSTANCE"));
   }
 
   // Helper method to help stub endpoints

--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -93,7 +93,7 @@ public class ResourceTranslator {
       Arrays.asList(
           AttributeMapping.create("module_id", ResourceAttributes.FAAS_NAME),
           AttributeMapping.create("version_id", ResourceAttributes.FAAS_VERSION),
-          AttributeMapping.create("instance_id", ResourceAttributes.FAAS_INSTANCE),
+          AttributeMapping.create("instance_id", ResourceAttributes.FAAS_ID),
           AttributeMapping.create("location", ResourceAttributes.CLOUD_REGION));
   private static List<AttributeMapping> GENERIC_TASK_LABELS =
       Arrays.asList(
@@ -106,8 +106,7 @@ public class ResourceTranslator {
           AttributeMapping.create("job", ResourceAttributes.SERVICE_NAME, ""),
           AttributeMapping.create(
               "task_id",
-              Arrays.asList(
-                  ResourceAttributes.SERVICE_INSTANCE_ID, ResourceAttributes.FAAS_INSTANCE),
+              Arrays.asList(ResourceAttributes.SERVICE_INSTANCE_ID, ResourceAttributes.FAAS_ID),
               ""));
 
   /** Converts a Java OpenTelemetry SDK resource into a GCP resource. */


### PR DESCRIPTION
This reverts commit 4ecc4f470819d1edd7b7d109397a4ffa9259fe7c.

This is to check and see if it fixes #268