### PR TITLE
Fix cloudfunctions test

### DIFF
--- a/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
+++ b/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/ScenarioHandlerManager.java
@@ -31,7 +31,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.time.Duration;
@@ -228,7 +228,7 @@ public class ScenarioHandlerManager {
                     new XCloudTraceContextPropagator(true))))
         .setTracerProvider(
             SdkTracerProvider.builder()
-                .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build())
+                .addSpanProcessor(SimpleSpanProcessor.create(traceExporter))
                 .setResource(resource)
                 .build())
         .build();


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/268

It uses a synchronous export of spans to ensure spans are delivered before cloud functions reclaims the CPU.