### PR TITLE
Update mappings for generic_task and generic_node

### DIFF
--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -103,7 +103,10 @@ public class ResourceTranslator {
                   ResourceAttributes.CLOUD_AVAILABILITY_ZONE, ResourceAttributes.CLOUD_REGION),
               "global"),
           AttributeMapping.create("namespace", ResourceAttributes.SERVICE_NAMESPACE, ""),
-          AttributeMapping.create("job", ResourceAttributes.SERVICE_NAME, ""),
+          AttributeMapping.create(
+              "job",
+              Arrays.asList(ResourceAttributes.SERVICE_NAME, ResourceAttributes.FAAS_NAME),
+              ""),
           AttributeMapping.create(
               "task_id",
               Arrays.asList(

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -169,11 +169,12 @@ public class ResourceTranslatorTest {
   }
 
   @Test
-  public void testMapResourcesWithGenericTaskFallbackFAAS() {
+  public void testMapResourcesWithGenericTaskFallback_FAASIgnored() {
     Map<AttributeKey<String>, String> testAttributes =
         java.util.stream.Stream.of(
                 new Object[][] {
-                  {ResourceAttributes.FAAS_NAME, "my-service-name"},
+                  {ResourceAttributes.SERVICE_NAME, "my-service-prevailed"},
+                  {ResourceAttributes.FAAS_NAME, "my-service-ignored"},
                   {ResourceAttributes.SERVICE_NAMESPACE, "prod"},
                   {ResourceAttributes.FAAS_INSTANCE, "1234"}
                 })
@@ -194,7 +195,84 @@ public class ResourceTranslatorTest {
     Map<String, String> expectedMappings =
         Stream.of(
                 new Object[][] {
-                  {"job", "my-service-name"},
+                  {"job", "my-service-prevailed"},
+                  {"namespace", "prod"},
+                  {"task_id", "1234"},
+                  {"location", "global"},
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesWithGenericTaskFallback_FAASPrevailed() {
+    Map<AttributeKey<String>, String> testAttributes =
+        java.util.stream.Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.SERVICE_NAME, "unknown_service_foo"},
+                  {ResourceAttributes.FAAS_NAME, "my-service-faas"},
+                  {ResourceAttributes.SERVICE_NAMESPACE, "prod"},
+                  {ResourceAttributes.FAAS_INSTANCE, "1234"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(attrBuilder::put);
+    Attributes attributes = attrBuilder.build();
+
+    GcpResource monitoredResource =
+        ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
+
+    assertEquals("generic_task", monitoredResource.getResourceType());
+
+    Map<String, String> monitoredResourceMap = monitoredResource.getResourceLabels().getLabels();
+    assertEquals(4, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"job", "my-service-faas"},
+                  {"namespace", "prod"},
+                  {"task_id", "1234"},
+                  {"location", "global"},
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesWithGenericTaskFallback_UnknownService() {
+    Map<AttributeKey<String>, String> testAttributes =
+        java.util.stream.Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.SERVICE_NAME, "unknown_service_foo"},
+                  {ResourceAttributes.SERVICE_NAMESPACE, "prod"},
+                  {ResourceAttributes.FAAS_INSTANCE, "1234"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(attrBuilder::put);
+    Attributes attributes = attrBuilder.build();
+
+    GcpResource monitoredResource =
+        ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
+
+    assertEquals("generic_task", monitoredResource.getResourceType());
+
+    Map<String, String> monitoredResourceMap = monitoredResource.getResourceLabels().getLabels();
+    assertEquals(4, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"job", "unknown_service_foo"},
                   {"namespace", "prod"},
                   {"task_id", "1234"},
                   {"location", "global"},
@@ -235,6 +313,42 @@ public class ResourceTranslatorTest {
                   {"job", "my-service-name"},
                   {"namespace", "prod"},
                   {"task_id", "1234"},
+                  {"location", "global"},
+                })
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+    expectedMappings.forEach(
+        (key, value) -> {
+          assertEquals(value, monitoredResourceMap.get(key));
+        });
+  }
+
+  @Test
+  public void testMapResourcesFallbackServiceNameOnly() {
+    Map<AttributeKey<String>, String> testAttributes =
+        java.util.stream.Stream.of(
+                new Object[][] {
+                  {ResourceAttributes.SERVICE_NAME, "unknown_service"},
+                  {ResourceAttributes.SERVICE_NAMESPACE, "prod"}
+                })
+            .collect(
+                Collectors.toMap(data -> (AttributeKey<String>) data[0], data -> (String) data[1]));
+    AttributesBuilder attrBuilder = Attributes.builder();
+    testAttributes.forEach(attrBuilder::put);
+    Attributes attributes = attrBuilder.build();
+
+    GcpResource monitoredResource =
+        ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
+
+    assertEquals("generic_node", monitoredResource.getResourceType());
+
+    Map<String, String> monitoredResourceMap = monitoredResource.getResourceLabels().getLabels();
+    assertEquals(3, monitoredResourceMap.size());
+
+    Map<String, String> expectedMappings =
+        Stream.of(
+                new Object[][] {
+                  {"namespace", "prod"},
+                  {"node_id", ""},
                   {"location", "global"},
                 })
             .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -251,17 +251,16 @@ public class ResourceTranslatorTest {
     GcpResource monitoredResource =
         ResourceTranslator.mapResource(io.opentelemetry.sdk.resources.Resource.create(attributes));
 
-    assertEquals("generic_task", monitoredResource.getResourceType());
+    assertEquals("generic_node", monitoredResource.getResourceType());
 
     Map<String, String> monitoredResourceMap = monitoredResource.getResourceLabels().getLabels();
-    assertEquals(4, monitoredResourceMap.size());
+    assertEquals(3, monitoredResourceMap.size());
 
     Map<String, String> expectedMappings =
         Stream.of(
                 new Object[][] {
-                  {"job", ""},
                   {"namespace", ""},
-                  {"task_id", ""},
+                  {"node_id", ""},
                   {"location", "global"},
                 })
             .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));


### PR DESCRIPTION
Fixes #265 

This PR: 
 - adds missing faas.* attributes mappings for `generic_task`.
 - adds missing resource mapping for `generic_node`.