### PR TITLE
Make resource-detector compatible with Java 8

### DIFF
--- a/detectors/resources/build.gradle
+++ b/detectors/resources/build.gradle
@@ -15,6 +15,12 @@
  */
 description = 'Google Cloud resource provider for OpenTelemetry'
 
+afterEvaluate {
+	tasks.named("compileJava"){
+		options.release = 8
+	}
+}
+
 dependencies {
 	implementation(libraries.opentelemetry_api)
 	implementation(libraries.opentelemetry_sdk)


### PR DESCRIPTION
### Description
This PR makes the resource detector Java 8 compatible. This is to support #266.

#### How the changes were tested
 - Used the GCP Detector jar built from this change in a Java 8 application (running in a docker container) to successfully detect resources. The Java 8 application was similar to [resource-example](examples/resource/src/main/java/com/google/cloud/opentelemetry/example/resource/ResourceExample.java) in the current repo.
 - Used the `javap` tool to check the major version with which the classes was compiled - 
```sh
 javap -v javap -v detectors/resources/build/classes/java/main/com/google/cloud/opentelemetry/detectors/*.class | grep major
```
Output - 
```sh
  major version: 52
  major version: 52
  major version: 52
  major version: 52
```

Indicates all classes within resource detector are Java 8 compatible.

Other artifacts are still compiled & targeted for Java 11. 
```sh
javap -v exporters/*/build/classes/java/main/com/google/cloud/opentelemetry/*/*.class | grep major
```

Output - 
```sh
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
  major version: 55
```