### PR TITLE
Fixed spotless config for copyright year

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -7,3 +7,5 @@ sourceFileExtensions:
   - Dockerfile
 allowedCopyrightHolders:
   - Google LLC
+ignoreFiles:
+  - buildscripts/*

--- a/buildscripts/spotless.license.dockerfile
+++ b/buildscripts/spotless.license.dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright $YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.gradle
+++ b/buildscripts/spotless.license.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright $YEAR Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.java
+++ b/buildscripts/spotless.license.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright $YEAR Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.shell
+++ b/buildscripts/spotless.license.shell
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Google LLC
+# Copyright $YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buildscripts/spotless.license.yaml
+++ b/buildscripts/spotless.license.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright $YEAR Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The current config forces us to update the static year in the license header config(s) along with every year change - also causes the year in all files to update (rather than only updating the year in newly added files).

For details see [spotless documentation for license headers](https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#license-header). 