### PR TITLE
Enable resource-detection-support library for release

### DIFF
--- a/detectors/resources-support/gradle.properties
+++ b/detectors/resources-support/gradle.properties
@@ -1,0 +1,1 @@
+release.enabled=true


### PR DESCRIPTION
Enables gradle `publishing` task to run on the `detetctor-resources-support` module.