### PR TITLE
Use logstash-logback-encoder version that works with spring boot 2

### DIFF
--- a/examples/instrumentation-quickstart/pom.xml
+++ b/examples/instrumentation-quickstart/pom.xml
@@ -82,7 +82,9 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.4</version>
+              <!-- Cannot be updated until logback is updated to 1.3+, probably in the next
+                Spring Boot major version -->
+            <version>7.3</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
+++ b/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
@@ -26,7 +26,6 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.ComposeContainer;
@@ -47,7 +46,6 @@ public class DockerComposeTestsIT {
           .withBuild(true);
 
   @Test
-  @Ignore("TODO: Remove after fixing https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8979")
   public void testApp() throws InterruptedException, IOException, URISyntaxException {
     // Let the docker compose app run until some spans/logs/metrics are sent to
     // GCP


### PR DESCRIPTION
This is a port over of https://github.com/GoogleCloudPlatform/java-docs-samples/pull/8984/ to this repo.

The breakage was actually caused by upgrading logstash-encoder to 7.4 because [it does not support logback versions prior to 1.3.0](https://github.com/logfellow/logstash-logback-encoder#:~:text=Support%20for%20logback%20versions%20prior%20to%201.3.0%20was%20removed%20in%20logstash%2Dlogback%2Dencoder%207.4.). Spring Boot 2 uses an [older logback version](https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/dependency-versions.html).

