### PR TITLE
Quota project fix

### DIFF
--- a/examples/instrumentation-quickstart/README.md
+++ b/examples/instrumentation-quickstart/README.md
@@ -58,7 +58,7 @@ cd java-docs-samples/opentelemetry/spring-boot-instrumentation/
 export USERID="$(id -u)"
 # Specify the project ID
 export GOOGLE_CLOUD_PROJECT=<your project id>
-docker compose -f docker-compose.yaml -f docker-compose.adc.yaml up  --abort-on-container-exit
+docker compose -f docker-compose.yaml -f docker-compose.creds.yaml up  --abort-on-container-exit
 ```
 
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login

--- a/examples/instrumentation-quickstart/docker-compose.creds.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.creds.yaml
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use this compose file along with docker-compose.yaml to pass Application Default
-# Credentials from the host into the collector container:
+# Use this compose file along with docker-compose.yaml to pass a credentials file from the host
+# into the collector container:
 #
 # ```
-# export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
-# docker compose -f docker-compose.yaml -f docker-compose.adc.yaml up
+# GOOGLE_CLOUD_PROJECT="otel-quickstart-demos" \
+# GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json" \
+# USERID="$(id -u)" \
+# docker compose -f docker-compose.yaml -f docker-compose.creds.yaml up --abort-on-container-exit
 # ```
 
 version: "3"
@@ -26,8 +28,8 @@ services:
   otelcol:
     # If the collector does not have permission to read the mounted volumes, set
     # USERID=$(id -u) to run the container as the current user
-    user: ${USERID}
+    user: $USERID
     volumes:
-      - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/tmp/keys/gcp-credentials.json:ro
+      - ${GOOGLE_APPLICATION_CREDENTIALS?}:${GOOGLE_APPLICATION_CREDENTIALS}:ro
     environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/gcp-credentials.json
+      - GOOGLE_APPLICATION_CREDENTIALS

--- a/examples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/examples/instrumentation-quickstart/otel-collector-config.yaml
@@ -72,8 +72,6 @@ exporters:
   # Export logs and traces using the standard googelcloud exporter
   googlecloud:
     project: $GOOGLE_CLOUD_PROJECT
-    # Needed when using Application Default Credentials in Cloud Shell to call Cloud Trace
-    # destination_project_quota: true
     log:
       default_log_name: "opentelemetry.io/collector-exported-log"
   # Export metrics to Google Managed service for Prometheus

--- a/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
+++ b/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
@@ -35,7 +35,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class DockerComposeTestsIT {
   @ClassRule
   public static ComposeContainer environment =
-      new ComposeContainer(new File("docker-compose.yaml"), new File("docker-compose.adc.yaml"))
+      new ComposeContainer(new File("docker-compose.yaml"), new File("docker-compose.creds.yaml"))
           .withEnv("USERID", System.getenv("USERID"))
           .withEnv("GOOGLE_CLOUD_PROJECT", getenvNotNull("GOOGLE_CLOUD_PROJECT"))
           .withEnv(


### PR DESCRIPTION

Cloud Trace API requires a quota project. This change passes through `GOOGLE_CLOUD_QUOTA_PROJECT` environment variable, which Cloud Shell has automatically set. This is better than doing the resource project override and works better off Cloud Shell. I also renamed the file to reflect that it works with any credentials file, including SA keys.

Equivalent of https://github.com/GoogleCloudPlatform/golang-samples/pull/3760 from the Go repo