### PR TITLE
Add CI for examples/instrumentation-quickstart

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,34 +6,54 @@ on:
       - main
 jobs:
   test:
-    name: Test
+    strategy:
+      matrix:
+        include:
+          - build-root: .
+            name: root
+            java-version: 11
+          - build-root: examples/instrumentation-quickstart
+            java-version: 17
+    name: Test (${{matrix.name || matrix.build-root}})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - id: setup-java-11
-        name: Setup Java 11
+      - id: setup-java
+        name: Setup Java ${{matrix.java-version}}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{matrix.java-version}}
       - uses: burrunan/gradle-cache-action@v1.6
         with:
+          job-id: java-${{matrix.java-version}}
           remote-build-cache-proxy-enabled: false
+          build-root-directory: ${{matrix.build-root}}
           arguments: test
   style:
-    name: Stylecheck
+    name: Stylecheck (${{matrix.name || matrix.build-root}})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - build-root: .
+            name: root
+            java-version: 11
+          - build-root: examples/instrumentation-quickstart
+            java-version: 17
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - id: setup-java-11
-        name: Setup Java 11
+      - id: setup-java
+        name: Setup Java ${{matrix.java-version}}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{matrix.java-version}}
       - uses: burrunan/gradle-cache-action@v1.6
         with:
+          job-id: java-${{matrix.java-version}}
           remote-build-cache-proxy-enabled: false
+          build-root-directory: ${{matrix.build-root}}
           arguments: spotlessCheck

--- a/examples/instrumentation-quickstart/.dockerignore
+++ b/examples/instrumentation-quickstart/.dockerignore
@@ -24,3 +24,4 @@ bin/
 Dockerfile
 docker-compose*.yaml
 otel-collector-config.yaml
+cloudbuild-integration.yaml

--- a/examples/instrumentation-quickstart/build.gradle
+++ b/examples/instrumentation-quickstart/build.gradle
@@ -18,6 +18,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.18'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'com.example'
@@ -26,6 +27,16 @@ description = 'OpenTelemetry instrumentation quickstart using Spring Boot'
 
 repositories {
 	mavenCentral()
+}
+
+spotless {
+	java {
+		googleJavaFormat("1.10.0")
+	}
+	groovyGradle {
+		target '*.gradle' // default target of groovyGradle
+		greclipse()
+	}
 }
 
 dependencies {
@@ -44,12 +55,18 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform {
 		// Individual integration tests are annotated with @Tag('integrationTest')
-        excludeTags 'integrationTest'
-    }
+		excludeTags 'integrationTest'
+	}
 }
 
 tasks.register("integrationTest", Test) {
-    useJUnitPlatform {
+	useJUnitPlatform {
 		includeTags 'integrationTest'
-    }
+	}
+
+	// Passing -DcomposeOverrideFile=foo.yaml will merge docker-compose.yaml with foo.yaml.
+	// This is used to set overrides for Cloud Build.
+	if (System.getProperty('composeOverrideFile')) {
+		systemProperty 'composeOverrideFile', System.getProperty('composeOverrideFile')
+	}
 }

--- a/examples/instrumentation-quickstart/cloudbuild-integration.yaml
+++ b/examples/instrumentation-quickstart/cloudbuild-integration.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: eclipse-temurin:17-jdk-alpine
+    id: integration-test
+    dir: examples/instrumentation-quickstart
+    script: ./gradlew integrationTest -i -DcomposeOverrideFile=docker-compose.test.yaml
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/examples/instrumentation-quickstart/docker-compose.test.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.test.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This compose file is only used for integration tests in Cloud Build
+
+version: "3"
+
+networks:
+  # Make containers use default Cloud Build network for ADC
+  # https://cloud.google.com/build/docs/build-config-file-schema#network
+  default:
+    name: cloudbuild
+    external: true

--- a/examples/instrumentation-quickstart/docker-compose.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
       - OTEL_SERVICE_NAME=otel-quickstart-spring-boot
       - OTEL_METRIC_EXPORT_INTERVAL=5000
-      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT?}
+      - GOOGLE_CLOUD_PROJECT
     volumes:
       - logs:/var/log:rw
     depends_on:
@@ -32,7 +32,7 @@ services:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - logs:/var/log:ro
     environment:
-      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT?}
+      - GOOGLE_CLOUD_PROJECT
   loadgen:
     image: golang:1.21
     command:

--- a/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
+++ b/examples/instrumentation-quickstart/src/test/java/com/example/demo/DockerComposeTestsIT.java
@@ -37,11 +37,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class DockerComposeTestsIT {
   @Container
   public static ComposeContainer environment =
-      new ComposeContainer(new File("docker-compose.yaml"), new File("docker-compose.creds.yaml"))
+      new ComposeContainer(
+              new File("docker-compose.yaml"),
+              new File(System.getProperty("composeOverrideFile", "docker-compose.creds.yaml")))
           .withEnv("USERID", System.getenv("USERID"))
-          .withEnv("GOOGLE_CLOUD_PROJECT", getenvNotNull("GOOGLE_CLOUD_PROJECT"))
+          .withEnv("GOOGLE_CLOUD_PROJECT", System.getenv("GOOGLE_CLOUD_PROJECT"))
           .withEnv(
-              "GOOGLE_APPLICATION_CREDENTIALS", getenvNotNull("GOOGLE_APPLICATION_CREDENTIALS"))
+              "GOOGLE_APPLICATION_CREDENTIALS", System.getenv("GOOGLE_APPLICATION_CREDENTIALS"))
           .withExposedService("app", 8080)
           .withExposedService("otelcol", 8888)
           .waitingFor("app", Wait.forHttp("/multi"))
@@ -81,14 +83,5 @@ public class DockerComposeTestsIT {
               Pattern.MULTILINE);
       assertThat(promText).containsMatch(re);
     }
-  }
-
-  private static String getenvNotNull(String key) {
-    String val = System.getenv(key);
-    if (val == null) {
-      throw new IllegalArgumentException(
-          "Environment variable " + key + " is required but was not set");
-    }
-    return val;
   }
 }


### PR DESCRIPTION
Adds GHA matrices for testing/style checking and Cloud Build trigger for running integration test. The Cloud Build trigger is only run when files under `examples/instrumentation-quickstart` are touched.