### PR TITLE
Add OTLP trace with ADC example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,6 @@ subprojects {
 			auto_value_annotations           : "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
 			auto_value                       : "com.google.auto.value:auto-value:${autoValueVersion}",
 			cloudevents_core                 : "io.cloudevents:cloudevents-core:${cloudEventsCoreVersion}",
-      google_auth                      : "com.google.auth:google-auth-library-oauth2-http:1.23.0",
 			google_cloud_core                : "com.google.cloud:google-cloud-core:${googleCloudVersion}",
 			google_cloud_trace               : "com.google.cloud:google-cloud-trace:${googleTraceVersion}",
 			google_cloud_trace_grpc          : "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleTraceVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ subprojects {
 			auto_value_annotations           : "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
 			auto_value                       : "com.google.auto.value:auto-value:${autoValueVersion}",
 			cloudevents_core                 : "io.cloudevents:cloudevents-core:${cloudEventsCoreVersion}",
+      google_auth                      : "com.google.auth:google-auth-library-oauth2-http:1.23.0",
 			google_cloud_core                : "com.google.cloud:google-cloud-core:${googleCloudVersion}",
 			google_cloud_trace               : "com.google.cloud:google-cloud-trace:${googleTraceVersion}",
 			google_cloud_trace_grpc          : "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleTraceVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ subprojects {
 		autoServiceVersion = '1.1.1'
 		autoValueVersion = '1.10.4'
 		slf4jVersion = '2.0.9'
+		googleAuthVersion = '1.23.0'
 		googleCloudVersion = '2.27.0'
 		googleTraceVersion = '2.30.0'
 		googleCloudBom = '26.26.0'
@@ -169,6 +170,7 @@ subprojects {
 			auto_value_annotations           : "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
 			auto_value                       : "com.google.auto.value:auto-value:${autoValueVersion}",
 			cloudevents_core                 : "io.cloudevents:cloudevents-core:${cloudEventsCoreVersion}",
+			google_auth                      : "com.google.auth:google-auth-library-oauth2-http:${googleAuthVersion}",
 			google_cloud_core                : "com.google.cloud:google-cloud-core:${googleCloudVersion}",
 			google_cloud_trace               : "com.google.cloud:google-cloud-trace:${googleTraceVersion}",
 			google_cloud_trace_grpc          : "com.google.api.grpc:grpc-google-cloud-trace-v2:${googleTraceVersion}",

--- a/examples/otlptrace/README.md
+++ b/examples/otlptrace/README.md
@@ -1,0 +1,27 @@
+# OTLP Trace with Google Auth Example
+
+Run this sample to connect to an endpoint that is protected by GCP authentication.
+
+First, get GCP credentials on your machine:
+
+```shell
+gcloud auth application-default login
+```
+Executing this command will save your application credentials to default path which will depend on the type of machine -
+ - Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+ - Windows: `%APPDATA%\gcloud\application_default_credentials.json`
+
+Next, set your endpoint with the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable:
+
+```shell
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-endpoint:port"
+```
+
+Next, update [`build.gradle`](build.grade) to set the following:
+
+```
+	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT_ID>,
+	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
+```
+
+Finally, run `gradle run` to run the sample.

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+	id 'java'
+	id 'application'
+}
+
+mainClassName = 'com.google.cloud.opentelemetry.example.otlptrace.OTLPTraceExample'
+
+description = 'Example for OTLP exporter'
+
+dependencies {
+	implementation(libraries.opentelemetry_api)
+	implementation(libraries.opentelemetry_sdk)
+	implementation(libraries.opentelemetry_otlp_exporter)
+	implementation(libraries.google_auth)
+}

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -26,15 +26,15 @@ dependencies {
 	implementation(libraries.opentelemetry_api)
 	implementation(libraries.opentelemetry_sdk)
 	implementation(libraries.opentelemetry_otlp_exporter)
-	implementation(libraries.google_auth)
 	implementation(libraries.opentelemetry_sdk_autoconf)
+	implementation(libraries.google_auth)
 }
 
 // Provide headers from env variable
-// export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer $(gcloud auth print-access-token),X-Goog-User-Project=otel-test-starter"
 // export OTEL_EXPORTER_OTLP_ENDPOINT="http://path/to/yourendpoint:port"
 def autoconf_config = [
-	'-Dotel.resource.attributes=gcp.project_id=otel-test-starter',
+	'-Dotel.resource.attributes=gcp.project_id=your-gcp-project',
+	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=your-gcp-project',
 	'-Dotel.traces.exporter=otlp',
 	'-Dotel.java.global-autoconfigure.enabled=true',
 ]

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -27,4 +27,18 @@ dependencies {
 	implementation(libraries.opentelemetry_sdk)
 	implementation(libraries.opentelemetry_otlp_exporter)
 	implementation(libraries.google_auth)
+	implementation(libraries.opentelemetry_sdk_autoconf)
+}
+
+// Provide headers from env variable
+// export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer $(gcloud auth print-access-token),X-Goog-User-Project=otel-test-starter"
+// export OTEL_EXPORTER_OTLP_ENDPOINT="http://path/to/yourendpoint:port"
+def autoconf_config = [
+	'-Dotel.resource.attributes=gcp.project_id=otel-test-starter',
+	'-Dotel.traces.exporter=otlp',
+	'-Dotel.java.global-autoconfigure.enabled=true',
+]
+
+application {
+	applicationDefaultJvmArgs = autoconf_config
 }

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -33,9 +33,10 @@ dependencies {
 // Provide headers from env variable
 // export OTEL_EXPORTER_OTLP_ENDPOINT="http://path/to/yourendpoint:port"
 def autoconf_config = [
-	'-Dotel.resource.attributes=gcp.project_id=your-gcp-project',
-	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=your-gcp-project',
+	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT>',
+	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
 	'-Dotel.traces.exporter=otlp',
+	'-Dotel.exporter.otlp.protocol=http/protobuf',
 	'-Dotel.java.global-autoconfigure.enabled=true',
 ]
 

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -15,14 +15,11 @@
  */
 package com.google.cloud.opentelemetry.example.otlptrace;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -33,22 +30,9 @@ public class OTLPTraceExample {
 
   private static OpenTelemetrySdk openTelemetrySdk;
 
-  private static OpenTelemetrySdk setupTraceExporter() throws IOException {
-    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
-
-    // Register the TraceExporter with OpenTelemetry
-    return OpenTelemetrySdk.builder()
-        .setTracerProvider(
-            SdkTracerProvider.builder()
-                .addSpanProcessor(
-                    BatchSpanProcessor.builder(
-                            OtlpHttpSpanExporter.builder()
-                                .addHeader(
-                                    "Authorization", "Bearer " + credentials.getAccessToken())
-                                .build())
-                        .build())
-                .build())
-        .buildAndRegisterGlobal();
+  private static OpenTelemetrySdk setupTraceExporter() {
+    // Let the SDK configure itself using environment variables and system properties
+    return AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
   }
 
   private static void myUseCase(String description) {

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.opentelemetry.example.otlptrace;
+
+import com.google.auth.oauth2.GoogleCredentials;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.export.OtlpHttpSpanExporter;
+import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class TraceExporterExample {
+  private static final String INSTRUMENTATION_SCOPE_NAME = TraceExporterExample.class.getName();
+  private static final Random random = new Random();
+
+  private static OpenTelemetrySdk openTelemetrySdk;
+
+  private static OpenTelemetrySdk setupTraceExporter() {
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+
+    // Register the TraceExporter with OpenTelemetry
+    return OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                .addSpanProcessor(BatchSpanProcessor.builder(OtlpHttpSpanExporter.builder().addHeader("Authorization", "Bearer "+credentials.getAccessToken()).build()).build())
+                .build())
+            .buildAndRegisterGlobal();
+  }
+
+  private static void myUseCase(String description) {
+    // Generate a span
+    Span span =
+        openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE_NAME).spanBuilder(description).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      span.addEvent("Event A");
+      // Do some work for the use case
+      for (int i = 0; i < 3; i++) {
+        String work = String.format("%s - Work #%d", description, (i + 1));
+        doWork(work);
+      }
+
+      span.addEvent("Event B");
+    } finally {
+      span.end();
+    }
+  }
+
+  private static void doWork(String description) {
+    // Child span
+    Span span =
+        openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE_NAME).spanBuilder(description).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      // Simulate work: this could be simulating a network request or an expensive disk operation
+      Thread.sleep(100 + random.nextInt(5) * 100);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      span.end();
+    }
+  }
+
+  public static void main(String[] args) {
+    // Configure the OpenTelemetry pipeline with CloudTrace exporter
+    openTelemetrySdk = setupTraceExporter();
+
+    // Application-specific logic
+    myUseCase("One");
+    myUseCase("Two");
+
+    // Flush all buffered traces
+    CompletableResultCode completableResultCode =
+        openTelemetrySdk.getSdkTracerProvider().shutdown();
+    // wait till export finishes
+    completableResultCode.join(10000, TimeUnit.MILLISECONDS);
+  }
+}

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -13,39 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.cloud.opentelemetry.example.otlptrace;
 
 import com.google.auth.oauth2.GoogleCredentials;
-
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.sdk.trace.export.OtlpHttpSpanExporter;
-import java.time.Duration;
+import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-public class TraceExporterExample {
-  private static final String INSTRUMENTATION_SCOPE_NAME = TraceExporterExample.class.getName();
+public class OTLPTraceExample {
+  private static final String INSTRUMENTATION_SCOPE_NAME = OTLPTraceExample.class.getName();
   private static final Random random = new Random();
 
   private static OpenTelemetrySdk openTelemetrySdk;
 
-  private static OpenTelemetrySdk setupTraceExporter() {
+  private static OpenTelemetrySdk setupTraceExporter() throws IOException {
     GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
 
     // Register the TraceExporter with OpenTelemetry
     return OpenTelemetrySdk.builder()
-            .setTracerProvider(
-                SdkTracerProvider.builder()
-                .addSpanProcessor(BatchSpanProcessor.builder(OtlpHttpSpanExporter.builder().addHeader("Authorization", "Bearer "+credentials.getAccessToken()).build()).build())
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                .addSpanProcessor(
+                    BatchSpanProcessor.builder(
+                            OtlpHttpSpanExporter.builder()
+                                .addHeader(
+                                    "Authorization", "Bearer " + credentials.getAccessToken())
+                                .build())
+                        .build())
                 .build())
-            .buildAndRegisterGlobal();
+        .buildAndRegisterGlobal();
   }
 
   private static void myUseCase(String description) {
@@ -80,7 +83,7 @@ public class TraceExporterExample {
     }
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws IOException {
     // Configure the OpenTelemetry pipeline with CloudTrace exporter
     openTelemetrySdk = setupTraceExporter();
 

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -47,7 +47,7 @@ public class OTLPTraceExample {
     return autoConfOTelSdk.getOpenTelemetrySdk();
   }
 
-  // Configures span exporter using configuration from
+  // Modifies the span exporter initially auto-configured using environment variables
   private static SpanExporter addAuthorizationHeaders(
       SpanExporter exporter, GoogleCredentials credentials) {
     if (exporter instanceof OtlpHttpSpanExporter) {
@@ -61,7 +61,7 @@ public class OTLPTraceExample {
 
         return builder.build();
       } catch (IOException e) {
-        System.out.println("error");
+        System.out.println("error:" + e.getMessage());
       }
     }
     return exporter;

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -16,6 +16,7 @@
 package com.google.cloud.opentelemetry.example.otlptrace;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.AccessToken;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
@@ -24,6 +25,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.*;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -50,11 +52,17 @@ public class OTLPTraceExample {
   private static SpanExporter addAuthorizationHeaders(
       SpanExporter exporter, GoogleCredentials credentials) {
     if (exporter instanceof OtlpHttpSpanExporter) {
-      OtlpHttpSpanExporterBuilder builder =
-          ((OtlpHttpSpanExporter) exporter)
-              .toBuilder().addHeader("Authorization", "Bearer " + credentials.getAccessToken());
+      try {
+        credentials.refreshIfExpired();
+        OtlpHttpSpanExporterBuilder builder =
+            ((OtlpHttpSpanExporter) exporter)
+                .toBuilder().addHeader("Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
 
-      return builder.build();
+        return builder.build();
+      }
+      catch(IOException e) {
+        System.out.println("error");
+      }
     }
     return exporter;
   }

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -16,7 +16,6 @@
 package com.google.cloud.opentelemetry.example.otlptrace;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.AccessToken;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
@@ -56,11 +55,12 @@ public class OTLPTraceExample {
         credentials.refreshIfExpired();
         OtlpHttpSpanExporterBuilder builder =
             ((OtlpHttpSpanExporter) exporter)
-                .toBuilder().addHeader("Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
+                .toBuilder()
+                    .addHeader(
+                        "Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
 
         return builder.build();
-      }
-      catch(IOException e) {
+      } catch (IOException e) {
         System.out.println("error");
       }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ rootProject.name = "opentelemetry-operations-java"
 
 include ":exporter-trace"
 include ":examples-trace"
+include ":examples-otlptrace"
 include ":exporter-metrics"
 include ":examples-metrics"
 include ":exporter-auto"
@@ -44,6 +45,9 @@ project(':exporter-trace').projectDir =
 
 project(':examples-trace').projectDir =
 		"$rootDir/examples/trace" as File
+
+project(':examples-otlptrace').projectDir =
+		"$rootDir/examples/otlptrace" as File
 
 project(':exporter-metrics').projectDir =
 		"$rootDir/exporters/metrics" as File


### PR DESCRIPTION
Cobbled this together following docs from:

* https://opentelemetry.io/docs/languages/java/exporters/
* https://github.com/googleapis/google-auth-library-java
* https://github.com/googleapis/google-auth-library-java/blob/main/samples/snippets/src/main/java/AuthenticateExplicit.java
* https://cloud.google.com/java/docs/reference/google-auth-library/latest/com.google.auth.oauth2.GoogleCredentials
* https://javadoc.io/static/io.opentelemetry/opentelemetry-exporter-otlp-http-trace/1.14.0/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.html

Same idea as https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/800, https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/307, and https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/676