### PR TITLE
Update auto-exporter readme

### DIFF
--- a/exporters/auto/README.md
+++ b/exporters/auto/README.md
@@ -15,7 +15,7 @@ To leverage the GCP extensions to this, simply add the exporter-auto dependency 
 <dependency>
   <groupId>com.google.cloud.opentelemetry</groupId>
   <artifactId>exporter-auto</artifactId>
-  <version>0.26.0-alpha</version>
+  <version>0.27.0-alpha</version>
   <!-- Add the classifier if you explicitly wish to use the shaded variant -->
   <classifier>shaded</classifier>
 </dependency>
@@ -23,12 +23,12 @@ To leverage the GCP extensions to this, simply add the exporter-auto dependency 
 
 #### Gradle
 ```groovy
-implementation "com.google.cloud.opentelemetry:exporter-auto:0.26.0-alpha"
+implementation "com.google.cloud.opentelemetry:exporter-auto:0.27.0-alpha"
 ```
 
 To use the shaded variant with Gradle,
 ```groovy
-implementation "com.google.cloud.opentelemetry:exporter-auto:0.26.0-alpha:shaded"
+implementation "com.google.cloud.opentelemetry:exporter-auto:0.27.0-alpha:shaded"
 ```
 
 #### Shaded Local JAR
@@ -38,9 +38,9 @@ You can download the shaded JAR for `exporter-auto` from the following link -
 https://repo1.maven.org/maven2/com/google/cloud/opentelemetry/exporter-auto/<VERSION>-alpha/exporter-auto-<VERSION>-alpha-shaded.jar
 ```
 Replace `<VERSION>` with the version you wish to download. For instance, shaded
-variant for `v0.26.0`, will be found at -
+variant for `v0.27.0`, will be found at -
 
-`https://repo1.maven.org/maven2/com/google/cloud/opentelemetry/exporter-auto/0.26.0-alpha/exporter-auto-0.26.0-alpha-shaded.jar`
+`https://repo1.maven.org/maven2/com/google/cloud/opentelemetry/exporter-auto/0.27.0-alpha/exporter-auto-0.27.0-alpha-shaded.jar`
 
 **Note: Make sure to use the latest release [![LatestRelease][maven-image]][maven-url].**
 
@@ -63,7 +63,7 @@ You can use the auto-configuration jar as an [Extension][auto-extensions] to the
 To instrument metrics and traces using the `opentelemetry-javaagent`, `opentelemetry-operations-java-auto-<version>.jar` can be used to provide opentelemetry exporters.
 
 ```
-java -javaagent:path/to/opentelemetry-javaagent-<version>-all.jar \
+java -javaagent:path/to/opentelemetry-javaagent.jar \
      -Dotel.javaagent.extensions=path/to/opentelemetry-operations-java-auto-<version>.jar \
      -Dotel.traces.exporter=google_cloud_trace \
      -Dotel.metrics.exporter=google_cloud_monitoring \


### PR DESCRIPTION
Updates the javaagent path sample to reflect the updated naming in upstream. 

The existing sample naming in the doc seemed to be causing minor confusion as seen in #303 .

Also updates the import samples to use the latest dependency version.