### PR TITLE
Remove usage of deprecated TraceServiceStub methods

### DIFF
--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/InternalTraceExporter.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/InternalTraceExporter.java
@@ -27,6 +27,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.trace.v2.TraceServiceClient;
 import com.google.cloud.trace.v2.TraceServiceSettings;
 import com.google.cloud.trace.v2.stub.TraceServiceStub;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.ProjectName;
@@ -56,7 +57,8 @@ class InternalTraceExporter implements SpanExporter {
       Map.of("User-Agent", "opentelemetry-operations-java/" + TraceVersions.EXPORTER_VERSION);
   private static final HeaderProvider HEADER_PROVIDER = () -> HEADERS;
 
-  private static InternalTraceExporter createWithClient(
+  @VisibleForTesting
+  static InternalTraceExporter createWithClient(
       String projectId,
       CloudTraceClient cloudTraceClient,
       ImmutableMap<String, String> attributeMappings,
@@ -104,7 +106,7 @@ class InternalTraceExporter implements SpanExporter {
           configuration.getAttributeMapping(),
           configuration.getFixedAttributes());
     }
-    return InternalTraceExporter.createWithClient(
+    return new InternalTraceExporter(
         projectId,
         new CloudTraceClientImpl(TraceServiceClient.create(stub)),
         configuration.getAttributeMapping(),

--- a/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
+++ b/exporters/trace/src/main/java/com/google/cloud/opentelemetry/trace/TraceConfiguration.java
@@ -19,7 +19,6 @@ import com.google.api.client.util.Strings;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.trace.v2.stub.TraceServiceStub;
 import com.google.cloud.trace.v2.stub.TraceServiceStubSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -88,15 +87,6 @@ public abstract class TraceConfiguration {
   public final String getProjectId() {
     return getProjectIdSupplier().get();
   }
-
-  /**
-   * Returns a TraceServiceStub instance used to make RPC calls.
-   *
-   * @return the trace service stub.
-   */
-  @Nullable
-  @Deprecated
-  public abstract TraceServiceStub getTraceServiceStub();
 
   /**
    * Returns the endpoint where to write traces.
@@ -185,16 +175,6 @@ public abstract class TraceConfiguration {
       setProjectIdSupplier(() -> projectId);
       return this;
     }
-
-    /**
-     * Sets the trace service stub used to send gRPC calls.
-     *
-     * @deprecated("Use setTraceServiceEndpoint")
-     * @param traceServiceStub the {@code TraceServiceStub}.
-     * @return this.
-     */
-    @Deprecated
-    public abstract Builder setTraceServiceStub(TraceServiceStub traceServiceStub);
 
     /** Sets the endpoint where to write traces. Defaults to tracing.googleapis.com:443. */
     public abstract Builder setTraceServiceEndpoint(String endpoint);

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/FakeData.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/FakeData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.concurrent.TimeUnit;
+
+public class FakeData {
+  private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
+  private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
+
+  static final String aTraceId = "00000000000000000000000000000001";
+  static final String aSpanId = "0000000000000002";
+  static final SpanContext aSpanContext =
+      SpanContext.create(aTraceId, aSpanId, TraceFlags.getDefault(), TraceState.getDefault());
+
+  static final SpanData aSpanData =
+      TestSpanData.builder()
+          .setHasEnded(true)
+          .setSpanContext(aSpanContext)
+          .setName("FakeData.Span")
+          .setStatus(StatusData.ok())
+          .setStartEpochNanos(START_EPOCH_NANOS)
+          .setEndEpochNanos(END_EPOCH_NANOS)
+          .setKind(SpanKind.SERVER)
+          .setAttributes(Attributes.of(AttributeKey.stringKey("desc"), "fake_span"))
+          .build();
+}

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.opentelemetry.trace;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -25,6 +26,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.trace.v2.TraceServiceSettings;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import java.time.Duration;
 import java.util.Collections;
@@ -53,7 +55,9 @@ public class TraceConfigurationTest {
 
     assertNull(configuration.getCredentials());
     assertNotNull(configuration.getProjectId());
-    assertNull(configuration.getTraceServiceStub());
+    assertFalse(configuration.getInsecureEndpoint());
+    assertEquals(
+        configuration.getTraceServiceEndpoint(), TraceServiceSettings.getDefaultEndpoint());
     assertTrue(configuration.getFixedAttributes().isEmpty());
     assertEquals(TraceConfiguration.DEFAULT_DEADLINE, configuration.getDeadline());
   }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -15,15 +15,21 @@
  */
 package com.google.cloud.opentelemetry.trace;
 
+import static com.google.cloud.opentelemetry.trace.FakeData.aSpanData;
+import static com.google.cloud.opentelemetry.trace.TraceConfiguration.DEFAULT_ATTRIBUTE_MAPPING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.trace.v2.TraceServiceClient;
 import com.google.cloud.trace.v2.TraceServiceSettings;
+import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.ProjectName;
+import com.google.devtools.cloudtrace.v2.Span;
+import com.google.devtools.cloudtrace.v2.TruncatableString;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -34,13 +40,18 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TraceExporterTest {
@@ -51,6 +62,9 @@ public class TraceExporterTest {
       GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
 
   @Mock private TraceServiceClient mockedTraceServiceClient;
+  @Mock private CloudTraceClient mockCloudTraceClient;
+
+  @Captor private ArgumentCaptor<List<Span>> spanListCaptor;
 
   @After
   public void tearDown() {
@@ -69,7 +83,46 @@ public class TraceExporterTest {
     assertNotNull(exporter);
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void testExportSucceeds() {
+    Map<String, AttributeValue> fixedSpanAttributes =
+        Collections.singletonMap(
+            "test_span", AttributeValue.newBuilder().setBoolValue(true).build());
+    SpanExporter exporter =
+        InternalTraceExporter.createWithClient(
+            PROJECT_ID, mockCloudTraceClient, DEFAULT_ATTRIBUTE_MAPPING, fixedSpanAttributes);
+
+    // export fake span data
+    CompletableResultCode result = exporter.export(ImmutableList.of(aSpanData));
+    Mockito.verify(mockCloudTraceClient, Mockito.times(1))
+        .batchWriteSpans(Mockito.eq(ProjectName.of(PROJECT_ID)), spanListCaptor.capture());
+
+    assertTrue(result.isSuccess());
+    // check if the spans being exported have the expected span attributes
+    spanListCaptor
+        .getValue()
+        .forEach(
+            span -> {
+              assertEquals(aSpanData.getSpanId(), span.getSpanId());
+              // Check if agent label key is added as a span attribute
+              assertTrue(
+                  span.getAttributes()
+                      .getAttributeMapMap()
+                      .get("g.co/agent")
+                      .getStringValue()
+                      .toString()
+                      .contains("google-cloud-trace-exporter"));
+              assertEquals(
+                  span.getAttributes().getAttributeMapMap().get("test_span"),
+                  AttributeValue.newBuilder().setBoolValue(true).build());
+              assertEquals(
+                  span.getAttributes().getAttributeMapMap().get("desc"),
+                  AttributeValue.newBuilder()
+                      .setStringValue(TruncatableString.newBuilder().setValue("fake_span").build())
+                      .build());
+            });
+  }
+
   @Test
   public void verifyExporterWorksWithConfiguration() {
     try (MockedStatic<TraceServiceClient> mockedTraceServiceClient =


### PR DESCRIPTION
### Breaking Change
 - Removes the deprecated TraceServiceStub methods - `setTraceServiceStub` & `getTraceServiceStub`.

Fixes #198 
Re #277 