### PR TITLE
Add tests to verify OTel integration using in-memory exporter

### DIFF
--- a/examples/trace/build.gradle
+++ b/examples/trace/build.gradle
@@ -29,6 +29,16 @@ dependencies {
 	implementation(libraries.google_cloud_trace)
 	implementation project(':exporter-trace')
 	runtimeOnly(libraries.opentelemetry_gcp_resources)
+
+	testImplementation(testLibraries.opentelemetry_sdk_testing)
+	testImplementation(testLibraries.mockito)
+	testImplementation(testLibraries.junit5)
+	testRuntimeOnly(testLibraries.junit5_runtime)
+}
+
+test {
+	// Required to discover JUnit 5 tests
+	useJUnitPlatform()
 }
 
 // Set Docker image path here, e.g. using Google Container Registry or Docker Hub

--- a/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
+++ b/examples/trace/src/main/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExample.java
@@ -17,6 +17,7 @@ package com.google.cloud.opentelemetry.example.trace;
 
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
+import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -49,25 +50,33 @@ public class TraceExporterExample {
         .buildAndRegisterGlobal();
   }
 
-  private static void myUseCase(String description) {
+  @VisibleForTesting
+  static void myUseCase(OpenTelemetrySdk openTelemetrySdk, String description) {
     // Generate a span
     Span span =
         openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE_NAME).spanBuilder(description).startSpan();
     try (Scope scope = span.makeCurrent()) {
       span.addEvent("Event A");
+      span.setAttribute("test_span", true);
       // Do some work for the use case
       for (int i = 0; i < 3; i++) {
         String work = String.format("%s - Work #%d", description, (i + 1));
-        doWork(work);
+        doWork(openTelemetrySdk, work);
       }
 
+      span.setAttribute("work_loop", 3);
       span.addEvent("Event B");
     } finally {
       span.end();
     }
   }
 
-  private static void doWork(String description) {
+  private static void myUseCase(String description) {
+    // Generate a span
+    myUseCase(openTelemetrySdk, description);
+  }
+
+  private static void doWork(OpenTelemetrySdk openTelemetrySdk, String description) {
     // Child span
     Span span =
         openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE_NAME).spanBuilder(description).startSpan();

--- a/examples/trace/src/test/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExampleTest.java
+++ b/examples/trace/src/test/java/com/google/cloud/opentelemetry/example/trace/TraceExporterExampleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.example.trace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TraceExporterExampleTest {
+
+  private OpenTelemetrySdk testOTelSdk;
+  private InMemorySpanExporter testInMemorySpanExporter;
+
+  @BeforeEach
+  public void setupOTelSdk() {
+    testInMemorySpanExporter = InMemorySpanExporter.create();
+    SdkTracerProvider testTracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(testInMemorySpanExporter))
+            .build();
+
+    testOTelSdk = OpenTelemetrySdk.builder().setTracerProvider(testTracerProvider).build();
+  }
+
+  @AfterEach
+  public void cleanupOTelSdk() {
+    testOTelSdk.close();
+  }
+
+  @Test
+  public void testMyUseCase() {
+    TraceExporterExample.myUseCase(testOTelSdk, "test");
+    List<SpanData> spanItems = testInMemorySpanExporter.getFinishedSpanItems();
+    assertFalse(spanItems.isEmpty());
+
+    // assert on custom span attributes set by application
+    spanItems.stream()
+        .filter(spanData -> spanData.getName().equals("test"))
+        .map(SpanData::getAttributes)
+        .forEach(
+            spanAttributes -> {
+              assertEquals(true, spanAttributes.get(AttributeKey.booleanKey("test_span")));
+              assertEquals(3, spanAttributes.get(AttributeKey.longKey("work_loop")));
+            });
+  }
+}


### PR DESCRIPTION
Adding a unit test demonstrating the use of [InMemorySpanExporter](https://github.com/open-telemetry/opentelemetry-java/blob/f83c020d4d2a11f16be8af739790718bb3413cba/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemorySpanExporter.java) to verify spans generated by the application.

### Testing
 - Ran the sample and verified the attributes presence in the generated span.
 - The newly added test passed.

Re: #277 