### PR TITLE
Add missing GOOGLE_CLOUD_QUOTA_PROJECT environment variable to compose file

### DIFF
--- a/examples/instrumentation-quickstart/docker-compose.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - logs:/var/log:ro
     environment:
       - GOOGLE_CLOUD_PROJECT
+      - GOOGLE_CLOUD_QUOTA_PROJECT
   loadgen:
     image: golang:1.21
     command:


### PR DESCRIPTION
I forgot to add this line in https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/286. It passes through the standard quota project envvar which makes the sample work seamlessly on Cloud Shell