### PR TITLE
Update instrumentation quickstart to new region tag name

### DIFF
--- a/examples/instrumentation-quickstart/Dockerfile
+++ b/examples/instrumentation-quickstart/Dockerfile
@@ -27,8 +27,8 @@ ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
-# [START opentelemetry_instrumentation_javaagent_dockerfile]
+# [START opentelemetry_instrumentation_agent_dockerfile]
 RUN wget -O /opentelemetry-javaagent.jar https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar
 CMD sh -c "java -javaagent:/opentelemetry-javaagent.jar -cp app:app/lib/* com.example.demo.DemoApplication \
 	2>&1 | tee /var/log/app.log"
-# [END opentelemetry_instrumentation_javaagent_dockerfile]
+# [END opentelemetry_instrumentation_agent_dockerfile]


### PR DESCRIPTION
The `opentelemetry_instrumentation_agent_dockerfile` region tag is more general and can be referenced across different languages. I am using the same one for JS in https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/687

I have "pinned" the docs build to existing version to prevent breaking links in the docs.
