### PR TITLE
Add resource attributes as metric labels

### DIFF
--- a/exporters/metrics/build.gradle
+++ b/exporters/metrics/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation(platform(libraries.google_cloud_bom))
 	implementation(platform(libraries.opentelemetry_bom))
 	implementation(project(':shared-resourcemapping'))
-	testImplementation(libraries.opentelemetry_semconv)
+	implementation(libraries.opentelemetry_semconv)
 	testImplementation(testLibraries.junit)
 	testImplementation(testLibraries.mockito)
 	testImplementation(testLibraries.slf4j_simple)

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -129,8 +129,8 @@ public abstract class MetricConfiguration {
   public abstract String getMetricServiceEndpoint();
 
   /**
-   * Returns the {@link Predicate} based filter that determines which resource attributes to add to
-   * a metric label.
+   * Returns the {@link Predicate} based filter that determines which resource attributes to add as
+   * metric labels.
    *
    * <p>The default filter adds {@link ResourceAttributes#SERVICE_NAME}, {@link
    * ResourceAttributes#SERVICE_NAMESPACE}, and {@link ResourceAttributes#SERVICE_INSTANCE_ID} as

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricTranslator.java
@@ -64,13 +64,18 @@ public final class MetricTranslator {
   }
 
   static MetricDescriptor mapMetricDescriptor(
-      String prefix, MetricData metric, io.opentelemetry.sdk.metrics.data.PointData metricPoint) {
+      String prefix,
+      MetricData metric,
+      io.opentelemetry.sdk.metrics.data.PointData metricPoint,
+      Attributes extraLabels) {
     MetricDescriptor.Builder builder =
         MetricDescriptor.newBuilder()
             .setDisplayName(metric.getName())
             .setDescription(metric.getDescription())
             .setType(mapMetricType(metric.getName(), prefix))
             .setUnit(metric.getUnit());
+    // add extra labels if any
+    extraLabels.forEach((key, value) -> builder.addLabels(mapAttribute(key, prefix)));
     metricPoint
         .getAttributes()
         .forEach((key, value) -> builder.addLabels(mapAttribute(key, prefix)));

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -70,6 +70,9 @@ public class FakeData {
           .put(ResourceAttributes.HOST_ID, aHostId)
           .put(ResourceAttributes.CLOUD_AVAILABILITY_ZONE, aCloudZone)
           .put(ResourceAttributes.CLOUD_PROVIDER, "gcp")
+          .put(ResourceAttributes.SERVICE_NAME, "test-gce-service")
+          .put(ResourceAttributes.SERVICE_NAMESPACE, "test-gce-service-ns")
+          .put(ResourceAttributes.SERVICE_INSTANCE_ID, "test-gce-service-id")
           .put("extra_info", "extra")
           .put("not_gcp_resource", "value")
           .build();


### PR DESCRIPTION
#### Feature Addition
 - Adds user configurable option to attach `service.name`, `service.namespace` and `service.id` resource attributes to metric labels. 
 - This can be disabled by passing the provided `NO_RESOURCE_ATTRIBUTES` as the resource filter to the `MetricConfiguration` object.
 - The default metric configuration has been changed to use the `DEFAULT_RESOURCE_ATTRIBUTES_FILTER`. 

Note: This is similar to how the [Google Cloud Monitoring go exporter works](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/2be0414d564ce62759e2da63615b27103ab950d3/exporter/metric/option.go#L114).

#### Testing
 - When running the auto-instrumentation-example, `service_name` appears under metric labels on GCP console with the expected value.
 - When running the metric export example, `service_name` appears with `unknown_resource` since the example does not include resource detection.

#### Deprecation
 - Deprecates the current publicly available `AggregateByLabelMetricTimeSeriesBuilder` constructor in favor of one that also accepts a resource attribute filter in form of a predicate. The existing constructor uses the `NO_RESOURCE_ATTRIBUTES` to keep it in-line with the existing functionality.

fixes #313 