### PR TITLE
Disable release for gcp-resource-detector

### DIFF
--- a/detectors/resources/gradle.properties
+++ b/detectors/resources/gradle.properties
@@ -1,2 +1,2 @@
 release.qualifier=alpha
-release.enabled=true
+release.enabled=false


### PR DESCRIPTION
The GCP Resource Detector has been moved to the [upstream contrib repo](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-resources). 

This PR removes it from the general release cycle. The source code might be deleted from here in the future releases. 