### PR TITLE
Update maven-badges to link to sonatype central

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ See [Metrics Readme](exporters/metrics/README.md) for installation and usage ins
 See [Autoconfigure Readme](exporters/auto/README.md) for installation and usage instructions.
 
 
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/exporter-trace/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/exporter-trace
+[maven-image]: https://img.shields.io/maven-central/v/com.google.cloud.opentelemetry/exporter-trace?color=dark-green
+[maven-url]: https://central.sonatype.com/artifact/com.google.cloud.opentelemetry/exporter-trace

--- a/detectors/resources-support/README.md
+++ b/detectors/resources-support/README.md
@@ -10,5 +10,5 @@ The GCP environments supported by this library are -
 4. [Google Cloud Functions](https://cloud.google.com/functions?hl=en)
 5. [Google Cloud Run](https://cloud.google.com/run?hl=en)
 
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/detector-resources-support/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.opentelemetry/detector-resources-support
+[maven-image]: https://img.shields.io/maven-central/v/com.google.cloud.opentelemetry/detector-resources-support?color=dark-green
+[maven-url]: https://central.sonatype.com/artifact/com.google.cloud.opentelemetry/detector-resources-support


### PR DESCRIPTION
The badges are generated using https://shields.io.

[search.maven.org](http://search.maven.org/) is [being retired](https://central.sonatype.org/faq/what-happened-to-search-maven-org/) and is being replaced with Sonatype central. [seach.maven.org](https://search.maven.org)'s index is not being refreshed very consistently. For instance currently, the [last index refresh](https://search.maven.org/stats) was done on 3rd April - which is why it doesn't always show the latest version.

We currently use https://github.com/softwaremill/maven-badges to show the badges on our README (for our java-ops repo), it is backed by [search.maven.org](http://search.maven.org/).

Switching to shields.io allows us to generate dynamic badges which can be pointed to sonatype central servers to fetch the latest version.

*Shields.io has been previously used in [google-cloud-java](https://github.com/googleapis/google-cloud-java/blob/5423c116cb584c4fdccc8538f1dfe6607f00341f/README.md#L15) repository as well.*