### PR TITLE
Update quickstart sample to output correct severity strings

### DIFF
--- a/examples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/examples/instrumentation-quickstart/otel-collector-config.yaml
@@ -35,6 +35,18 @@ receivers:
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
         severity:
           parse_from: body.severity
+          preset: none
+          # parse minimal set of severity strings that Cloud Logging explicitly supports
+          # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+          mapping:
+            debug: debug
+            info: info
+            info3: notice
+            warn: warning
+            error: error
+            fatal: critical
+            fatal3: alert
+            fatal4: emergency
 
       # set trace_flags to SAMPLED if GCP attribute is set to true
       - type: add

--- a/examples/instrumentation-quickstart/src/main/resources/logback.xml
+++ b/examples/instrumentation-quickstart/src/main/resources/logback.xml
@@ -25,15 +25,16 @@
           {
             "logging.googleapis.com/trace": "%mdc{trace_id}",
             "logging.googleapis.com/spanId": "%mdc{span_id}",
-            "logging.googleapis.com/trace_sampled": "#asBoolean{%replace(%mdc{trace_flags}){'01', 'true'}}"
+            "logging.googleapis.com/trace_sampled": "#asBoolean{%replace(%mdc{trace_flags}){'01', 'true'}}",
+            "severity": "%replace(%replace(%level){'WARN', 'WARNING'}){'TRACE', 'DEBUG'}"
           }
         </pattern>
       </provider>
 
       <!-- Rename fields for the Logging agent -->
       <fieldNames>
-        <level>severity</level>
         <timestamp>timestamp</timestamp>
+        <level>[ignore]</level>
         <levelValue>[ignore]</levelValue>
       </fieldNames>
 


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/golang-samples/pull/3999, this
- makes the collector parse severity strings the same way the Cloud Logging agent does
- outputs the severity levels matching the [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity) enum. SLF4J levels are compatible except `TRACE` and `WARN`

manually tested by adding log statements and inspecting
```console
{"timestamp":"2024-04-17T17:54:22.598Z","@version":"1","message":"warn - handle /multi request with subRequests=7","logger_name":"com.example.demo.MultiController","thread_name":"reactor-http-epoll-2","logging.googleapis.com/trace":"661e81d941fc0bc07c533136df6edd30","logging.googleapis.com/spanId":"f99ecaa4b31acc1a","logging.googleapis.com/trace_sampled":true,"severity":"WARNING"}
```

```console
{"timestamp":"2024-04-17T17:54:22.598Z","@version":"1","message":"trace - handle /multi request with subRequests=7","logger_name":"com.example.demo.MultiController","thread_name":"reactor-http-epoll-2","logging.googleapis.com/trace":"661e81d941fc0bc07c533136df6edd30","logging.googleapis.com/spanId":"f99ecaa4b31acc1a","logging.googleapis.com/trace_sampled":true,"severity":"DEBUG"}
```
