### PR TITLE
Always output logging.googleapis.com/trace_sampled as true

### DIFF
--- a/examples/instrumentation-quickstart/src/main/resources/log4j2.xml
+++ b/examples/instrumentation-quickstart/src/main/resources/log4j2.xml
@@ -17,7 +17,8 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <!-- TODO(#331): output logging.googleapis.com/trace_sampled as a boolean -->
+      <!-- TODO(#331): output logging.googleapis.com/trace_sampled based on trace_flags instead
+      of hardcoding as true -->
       <!-- [START opentelemetry_instrumentation_setup_logging] -->
       <!-- Format JSON logs for the Cloud Logging agent
       https://cloud.google.com/logging/docs/structured-logging#special-payload-fields -->
@@ -36,6 +37,11 @@
           key="logging.googleapis.com/spanId"
           format="JSON"
           value='{"$resolver": "mdc", "key": "span_id"}'
+        />
+        <EventTemplateAdditionalField
+          key="logging.googleapis.com/trace_sampled"
+          format="JSON"
+          value="true"
         />
       </JsonTemplateLayout>
       <!-- [END opentelemetry_instrumentation_setup_logging] -->


### PR DESCRIPTION
If this field is not set to `true`, Cloud Logging will grey-out the "View trace details" feature. This is a better workaround until I have a real fix for #331
![image](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/assets/1510004/e7866cbe-7e07-45ac-83e3-c8d73568476f)