### PR TITLE
Update JVM flag otel.java.experimental.extension

### DIFF
--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -64,7 +64,7 @@ jib {
 		// Use the downloaded java agent.
 		'-javaagent:/otelagent/otel_agent.jar',
 		// Use the GCP exporter extensions.
-		'-Dotel.javaagent.experimental.extensions=/otelagent/gcp_ext.jar',
+		'-Dotel.javaagent.extensions=/otelagent/gcp_ext.jar',
 		// Configure auto instrumentation.
 		'-Dotel.traces.exporter=google_cloud_trace',
 		'-Dotel.metrics.exporter=google_cloud_monitoring',

--- a/propagators/gcp/README.md
+++ b/propagators/gcp/README.md
@@ -13,9 +13,9 @@ The preferred mechanism is to use the [SDK autoconfigure extension](https://gith
 
 - Add a runtime dependency from your java project to this library.
 - You can now use `oneway-gcp` and `gcp` as viable propagation strings in [the `otel.propagators` flag](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#propagator)
-- When using the autoinstrumentation agent, you also need to pass our propagators to the autoinstrumentation "extension" classpath. This can be done through the `otel.javaagent.experimental.extensions` flag. 
+- When using the autoinstrumentation agent, you also need to pas our propagators to the autoinstrumentation "extension" classpath. This can be done through the `otel.javaagent.extensions` flag.
     ```
-    -Dotel.javaagent.experimental.extensions=/path/to/downloaded/gcp-propagator.jar
+    -Dotel.javaagent.extensions=/path/to/downloaded/gcp-propagator.jar
     ```
     For a complete example see [here](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/blob/main/examples/autoinstrument/build.gradle#L63).
 


### PR DESCRIPTION
otel.java.experimental.extesion JVM Flag was updated to otel.java.extension since Release v1.30.0

### Testing
 - `./gradlew clean build`
 - Ran the auto-instrumentation sample to ensure that traces and metrics show up in GCP console.

Fixes #335 