### PR TITLE
Fix #340 bug

### DIFF
--- a/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
+++ b/shared/resourcemapping/src/main/java/com/google/cloud/opentelemetry/resource/ResourceTranslator.java
@@ -172,7 +172,7 @@ public class ResourceTranslator {
   public static GcpResource mapResource(Resource resource) {
     String platform = resource.getAttribute(ResourceAttributes.CLOUD_PLATFORM);
     if (platform == null) {
-      return genericTaskOrNode(resource);
+      return mapK8sResourceOrGenericTaskOrNode(resource);
     }
     switch (platform) {
       case ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE:
@@ -182,21 +182,25 @@ public class ResourceTranslator {
       case ResourceAttributes.CloudPlatformValues.GCP_APP_ENGINE:
         return mapBase(resource, "gae_instance", GOOGLE_CLOUD_APP_ENGINE_INSTANCE_LABELS);
       default:
-        // if k8s.cluster.name is set, pattern match for various k8s resources.
-        // this will also match non-cloud k8s platforms like minikube.
-        if (resource.getAttribute(ResourceAttributes.K8S_CLUSTER_NAME) != null) {
-          if (resource.getAttribute(ResourceAttributes.K8S_CONTAINER_NAME) != null) {
-            return mapBase(resource, "k8s_container", K8S_CONTAINER_LABELS);
-          } else if (resource.getAttribute(ResourceAttributes.K8S_POD_NAME) != null) {
-            return mapBase(resource, "k8s_pod", K8S_POD_LABELS);
-          } else if (resource.getAttribute(ResourceAttributes.K8S_NODE_NAME) != null) {
-            return mapBase(resource, "k8s_node", K8S_NODE_LABELS);
-          } else {
-            return mapBase(resource, "k8s_cluster", K8S_CLUSTER_LABELS);
-          }
-        }
-        return genericTaskOrNode(resource);
+        return mapK8sResourceOrGenericTaskOrNode(resource);
     }
+  }
+
+  private static GcpResource mapK8sResourceOrGenericTaskOrNode(Resource resource) {
+    // if k8s.cluster.name is set, pattern match for various k8s resources.
+    // this will also match non-cloud k8s platforms like minikube.
+    if (resource.getAttribute(ResourceAttributes.K8S_CLUSTER_NAME) != null) {
+      if (resource.getAttribute(ResourceAttributes.K8S_CONTAINER_NAME) != null) {
+        return mapBase(resource, "k8s_container", K8S_CONTAINER_LABELS);
+      } else if (resource.getAttribute(ResourceAttributes.K8S_POD_NAME) != null) {
+        return mapBase(resource, "k8s_pod", K8S_POD_LABELS);
+      } else if (resource.getAttribute(ResourceAttributes.K8S_NODE_NAME) != null) {
+        return mapBase(resource, "k8s_node", K8S_NODE_LABELS);
+      } else {
+        return mapBase(resource, "k8s_cluster", K8S_CLUSTER_LABELS);
+      }
+    }
+    return genericTaskOrNode(resource);
   }
 
   private static GcpResource genericTaskOrNode(Resource resource) {

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -41,24 +41,8 @@ public class ResourceTranslatorTest {
 
   private static Stream<Arguments> provideOTelResourceAttributesToMonitoredResourceMapping() {
     return Stream.of(
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE),
-                new SimpleEntry<>(ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.CLOUD_REGION, "country-region"),
-                new SimpleEntry<>(ResourceAttributes.HOST_ID, "GCE-instance-id"),
-                new SimpleEntry<>(ResourceAttributes.HOST_NAME, "GCE-instance-name"),
-                new SimpleEntry<>(ResourceAttributes.HOST_TYPE, "GCE-instance-type")),
-            "gce_instance",
-            Map.ofEntries(
-                new SimpleEntry<>("instance_id", "GCE-instance-id"),
-                new SimpleEntry<>("zone", "country-region-zone"))),
+        // test cases for k8s
+        // test cases for k8s_container on [GCP, AWS, Azure, non-cloud]
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
@@ -87,6 +71,65 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "EKS-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "EKS-pod-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CONTAINER_NAME, "EKS-container-name")),
+            "k8s_container",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
+                new SimpleEntry<>("namespace_name", "EKS-namespace-name"),
+                new SimpleEntry<>("pod_name", "EKS-pod-name"),
+                new SimpleEntry<>("container_name", "EKS-container-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "AKS-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "AKS-pod-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CONTAINER_NAME, "AKS-container-name")),
+            "k8s_container",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
+                new SimpleEntry<>("namespace_name", "AKS-namespace-name"),
+                new SimpleEntry<>("pod_name", "AKS-pod-name"),
+                new SimpleEntry<>("container_name", "AKS-container-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
+                new SimpleEntry<>(
+                    ResourceAttributes.K8S_NAMESPACE_NAME, "non-cloud-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "non-cloud-pod-name"),
+                new SimpleEntry<>(
+                    ResourceAttributes.K8S_CONTAINER_NAME, "non-cloud-container-name")),
+            "k8s_container",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
+                new SimpleEntry<>("namespace_name", "non-cloud-namespace-name"),
+                new SimpleEntry<>("pod_name", "non-cloud-pod-name"),
+                new SimpleEntry<>("container_name", "non-cloud-container-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        // test cases for k8s_pod on [GCP, AWS, Azure, non-cloud]
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
@@ -107,6 +150,58 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "EKS-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "EKS-pod-name")),
+            "k8s_pod",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
+                new SimpleEntry<>("pod_name", "EKS-pod-name"),
+                new SimpleEntry<>("namespace_name", "EKS-namespace-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "AKS-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "AKS-pod-name")),
+            "k8s_pod",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
+                new SimpleEntry<>("pod_name", "AKS-pod-name"),
+                new SimpleEntry<>("namespace_name", "AKS-namespace-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
+                new SimpleEntry<>(
+                    ResourceAttributes.K8S_NAMESPACE_NAME, "non-cloud-namespace-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "non-cloud-pod-name")),
+            "k8s_pod",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
+                new SimpleEntry<>("pod_name", "non-cloud-pod-name"),
+                new SimpleEntry<>("namespace_name", "non-cloud-namespace-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        // test cases for k8s_node on [GCP, AWS, Azure, non-cloud]
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
@@ -122,6 +217,51 @@ public class ResourceTranslatorTest {
                 new SimpleEntry<>("location", "country-region-zone"),
                 new SimpleEntry<>("node_name", "GKE-node-name"),
                 new SimpleEntry<>("cluster_name", "GKE-cluster-name"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "EKS-node-name")),
+            "k8s_node",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
+                new SimpleEntry<>("node_name", "EKS-node-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "AKS-node-name")),
+            "k8s_node",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
+                new SimpleEntry<>("node_name", "AKS-node-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "non-cloud-node-name")),
+            "k8s_node",
+            Map.ofEntries(
+                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
+                new SimpleEntry<>("node_name", "non-cloud-node-name"),
+                new SimpleEntry<>("location", "country-region-zone"))),
+        // test cases for k8s_cluster on [GCP, AWS, Azure, non-cloud]
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
@@ -170,169 +310,36 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "EKS-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "EKS-pod-name")),
-            "k8s_pod",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
-                new SimpleEntry<>("pod_name", "EKS-pod-name"),
-                new SimpleEntry<>("namespace_name", "EKS-namespace-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER,
-                    ResourceAttributes.CloudProviderValues.AZURE),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "AKS-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "AKS-pod-name")),
-            "k8s_pod",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
-                new SimpleEntry<>("pod_name", "AKS-pod-name"),
-                new SimpleEntry<>("namespace_name", "AKS-namespace-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "EKS-node-name")),
-            "k8s_node",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
-                new SimpleEntry<>("node_name", "EKS-node-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER,
-                    ResourceAttributes.CloudProviderValues.AZURE),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "AKS-node-name")),
-            "k8s_node",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
-                new SimpleEntry<>("node_name", "AKS-node-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "EKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "EKS-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "EKS-pod-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CONTAINER_NAME, "EKS-container-name")),
-            "k8s_container",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "EKS-cluster-name"),
-                new SimpleEntry<>("namespace_name", "EKS-namespace-name"),
-                new SimpleEntry<>("pod_name", "EKS-pod-name"),
-                new SimpleEntry<>("container_name", "EKS-container-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER,
-                    ResourceAttributes.CloudProviderValues.AZURE),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "AKS-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "AKS-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "AKS-pod-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CONTAINER_NAME, "AKS-container-name")),
-            "k8s_container",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "AKS-cluster-name"),
-                new SimpleEntry<>("namespace_name", "AKS-namespace-name"),
-                new SimpleEntry<>("pod_name", "AKS-pod-name"),
-                new SimpleEntry<>("container_name", "AKS-container-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
                 new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name")),
             "k8s_cluster",
             Map.ofEntries(
                 new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
                 new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
-                new SimpleEntry<>(
-                    ResourceAttributes.K8S_NAMESPACE_NAME, "non-cloud-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "non-cloud-pod-name")),
-            "k8s_pod",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
-                new SimpleEntry<>("pod_name", "non-cloud-pod-name"),
-                new SimpleEntry<>("namespace_name", "non-cloud-namespace-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "non-cloud-node-name")),
-            "k8s_node",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
-                new SimpleEntry<>("node_name", "non-cloud-node-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
-        generateOTelResourceMappingTestArgs(
-            Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
-                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
-                new SimpleEntry<>(
-                    ResourceAttributes.K8S_NAMESPACE_NAME, "non-cloud-namespace-name"),
-                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "non-cloud-pod-name"),
-                new SimpleEntry<>(
-                    ResourceAttributes.K8S_CONTAINER_NAME, "non-cloud-container-name")),
-            "k8s_container",
-            Map.ofEntries(
-                new SimpleEntry<>("cluster_name", "non-cloud-cluster-name"),
-                new SimpleEntry<>("namespace_name", "non-cloud-namespace-name"),
-                new SimpleEntry<>("pod_name", "non-cloud-pod-name"),
-                new SimpleEntry<>("container_name", "non-cloud-container-name"),
-                new SimpleEntry<>("location", "country-region-zone"))),
+        // test case for GCE Instance
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_COMPUTE_ENGINE),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_REGION, "country-region"),
+                new SimpleEntry<>(ResourceAttributes.HOST_ID, "GCE-instance-id"),
+                new SimpleEntry<>(ResourceAttributes.HOST_NAME, "GCE-instance-name"),
+                new SimpleEntry<>(ResourceAttributes.HOST_TYPE, "GCE-instance-type")),
+            "gce_instance",
+            Map.ofEntries(
+                new SimpleEntry<>("instance_id", "GCE-instance-id"),
+                new SimpleEntry<>("zone", "country-region-zone"))),
+        // test case for EC2 Instance
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AWS_EC2),
@@ -346,6 +353,7 @@ public class ResourceTranslatorTest {
                 new SimpleEntry<>("region", "country-region-zone"),
                 new SimpleEntry<>("instance_id", "aws-instance-id"),
                 new SimpleEntry<>("aws_account", "aws-id"))),
+        // test cases for generic_task
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(ResourceAttributes.SERVICE_NAME, "my-service-prevailed"),
@@ -392,6 +400,7 @@ public class ResourceTranslatorTest {
                 new SimpleEntry<>("namespace", "prod"),
                 new SimpleEntry<>("task_id", "1234"),
                 new SimpleEntry<>("location", "global"))),
+        // test cases for generic_node
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(ResourceAttributes.SERVICE_NAME, "unknown_service"),

--- a/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
+++ b/shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java
@@ -90,6 +90,60 @@ public class ResourceTranslatorTest {
                     ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_REGION, "country-region"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NAMESPACE_NAME, "GKE-testNameSpace"),
+                new SimpleEntry<>(ResourceAttributes.K8S_POD_NAME, "GKE-testHostName")),
+            "k8s_pod",
+            Map.ofEntries(
+                new SimpleEntry<>("location", "country-region-zone"),
+                new SimpleEntry<>("cluster_name", "GKE-cluster-name"),
+                new SimpleEntry<>("namespace_name", "GKE-testNameSpace"),
+                new SimpleEntry<>("pod_name", "GKE-testHostName"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_REGION, "country-region"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name"),
+                new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "GKE-node-name")),
+            "k8s_node",
+            Map.ofEntries(
+                new SimpleEntry<>("location", "country-region-zone"),
+                new SimpleEntry<>("node_name", "GKE-node-name"),
+                new SimpleEntry<>("cluster_name", "GKE-cluster-name"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
+                    ResourceAttributes.CloudPlatformValues.GCP_KUBERNETES_ENGINE),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_ACCOUNT_ID, "GCE-pid"),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
+                new SimpleEntry<>(ResourceAttributes.CLOUD_REGION, "country-region"),
+                new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "GKE-cluster-name")),
+            "k8s_cluster",
+            Map.ofEntries(
+                new SimpleEntry<>("location", "country-region-zone"),
+                new SimpleEntry<>("cluster_name", "GKE-cluster-name"))),
+        generateOTelResourceMappingTestArgs(
+            Map.ofEntries(
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
+                new SimpleEntry<>(
+                    ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AWS_EKS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
@@ -101,7 +155,8 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AZURE_AKS),
@@ -115,7 +170,7 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AWS_EKS),
@@ -133,7 +188,8 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AZURE_AKS),
@@ -151,7 +207,7 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AWS_EKS),
@@ -167,7 +223,8 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AZURE_AKS),
@@ -183,7 +240,7 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.AWS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AWS_EKS),
@@ -203,7 +260,8 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
+                    ResourceAttributes.CLOUD_PROVIDER,
+                    ResourceAttributes.CloudProviderValues.AZURE),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_PLATFORM,
                     ResourceAttributes.CloudPlatformValues.AZURE_AKS),
@@ -223,11 +281,6 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
-                new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
                 new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name")),
             "k8s_cluster",
@@ -236,11 +289,6 @@ public class ResourceTranslatorTest {
                 new SimpleEntry<>("location", "country-region-zone"))),
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AWS_EKS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
                 new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
@@ -256,11 +304,6 @@ public class ResourceTranslatorTest {
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
                 new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
-                new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
                 new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),
                 new SimpleEntry<>(ResourceAttributes.K8S_NODE_NAME, "non-cloud-node-name")),
@@ -271,11 +314,6 @@ public class ResourceTranslatorTest {
                 new SimpleEntry<>("location", "country-region-zone"))),
         generateOTelResourceMappingTestArgs(
             Map.ofEntries(
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PROVIDER, ResourceAttributes.CloudProviderValues.GCP),
-                new SimpleEntry<>(
-                    ResourceAttributes.CLOUD_PLATFORM,
-                    ResourceAttributes.CloudPlatformValues.AZURE_AKS),
                 new SimpleEntry<>(
                     ResourceAttributes.CLOUD_AVAILABILITY_ZONE, "country-region-zone"),
                 new SimpleEntry<>(ResourceAttributes.K8S_CLUSTER_NAME, "non-cloud-cluster-name"),


### PR DESCRIPTION
Fix #340 's bug.

I made bellow changes.

## 1. Use appropriate `CLOUD_PROVIDER` . 
- `shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java` All or most of test case's  `CLOUD_PROVIDER` are `GCP`.  But I think it is not correct. It should map bellow.
  - When `GCP_KUBERNETES_ENGINE ` then `GCP`
  - When `AZURE_AKS` then `AZURE`
  - When `AWS_EKS` then `AWS`
  - When null then no key and value. (not cloud)
- This mapping follows Go's repository. Like here.  https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/683/files#diff-68a9a0e83deda8fe72338c49bcedd7da9b1633f67d40473059117d9db844529aR130-R343
- **So I fixed about `CLOUD_PROVIDER` in most of cases.**

## 2. Use appropriate `CLOUD_PLATFORM`.
- `shared/resourcemapping/src/test/java/com/google/cloud/opentelemetry/resource/ResourceTranslatorTest.java` All or most `non-cloud` test case's `CLOUD_PLATFORM` are `AZURE_AKS`. But it should be no keys and values.
  - here: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/342/files#diff-bbe578011b0d984210caf2aa4e41a2c6020f0580d15396d6be3be7aff4819289L223-L293
- **So I remove keys and values.**

## 3. Add test cases about `GCP` .
- I did it. https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/342#discussion_r1597457360

## 4. Fix to map resource when `platform == null`

I have to map to k8s resources when this condition. If i did this.

> ## 2. Use appropriate `CLOUD_PLATFORM`.

Then I need duplicate these lines https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/342/files#diff-992354fc4c9a5bcfac13812fb9e420d0498483ae56b986f25e71d6649386de99L187-L198 . So I make `mapK8sResourceOrGenericTaskOrNode` to refactor it.
