### PR TITLE
Add support for custom MR mappings

### DIFF
--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -59,14 +59,14 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
   private final String projectId;
   private final String prefix;
   private final Predicate<AttributeKey<?>> resourceAttributeFilter;
-  private final MonitoredResourceMapping monitoredResourceMapping;
+  private final MonitoredResourceDescription monitoredResourceDescription;
 
   @Deprecated
   public AggregateByLabelMetricTimeSeriesBuilder(String projectId, String prefix) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
-    this.monitoredResourceMapping = MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
+    this.monitoredResourceDescription = MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
   }
 
   @Deprecated
@@ -75,18 +75,18 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
-    this.monitoredResourceMapping = MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
+    this.monitoredResourceDescription = MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
   }
 
   public AggregateByLabelMetricTimeSeriesBuilder(
       String projectId,
       String prefix,
       Predicate<AttributeKey<?>> resourceAttributeFilter,
-      MonitoredResourceMapping monitoredResourceMapping) {
+      MonitoredResourceDescription monitoredResourceDescription) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
-    this.monitoredResourceMapping = monitoredResourceMapping;
+    this.monitoredResourceDescription = monitoredResourceDescription;
   }
 
   @Override
@@ -150,7 +150,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     return TimeSeries.newBuilder()
         .setMetric(mapMetric(attributes, descriptor.getType()))
         .setMetricKind(descriptor.getMetricKind())
-        .setResource(mapResource(metric.getResource(), monitoredResourceMapping));
+        .setResource(mapResource(metric.getResource(), monitoredResourceDescription));
   }
 
   private Attributes extraLabelsFromResource(Resource resource) {

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -66,7 +66,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
-    this.monitoredResourceDescription = MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
+    this.monitoredResourceDescription = MetricConfiguration.EMPTY_MONITORED_RESOURCE_DESCRIPTION;
   }
 
   @Deprecated
@@ -75,7 +75,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
-    this.monitoredResourceDescription = MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
+    this.monitoredResourceDescription = MetricConfiguration.EMPTY_MONITORED_RESOURCE_DESCRIPTION;
   }
 
   public AggregateByLabelMetricTimeSeriesBuilder(

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -59,19 +59,34 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
   private final String projectId;
   private final String prefix;
   private final Predicate<AttributeKey<?>> resourceAttributeFilter;
+  private final MonitoredResourceMapping monitoredResourceMapping;
 
   @Deprecated
   public AggregateByLabelMetricTimeSeriesBuilder(String projectId, String prefix) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
+    this.monitoredResourceMapping = MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
   }
 
+  @Deprecated
   public AggregateByLabelMetricTimeSeriesBuilder(
       String projectId, String prefix, Predicate<AttributeKey<?>> resourceAttributeFilter) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
+    this.monitoredResourceMapping = MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
+  }
+
+  public AggregateByLabelMetricTimeSeriesBuilder(
+      String projectId,
+      String prefix,
+      Predicate<AttributeKey<?>> resourceAttributeFilter,
+      MonitoredResourceMapping monitoredResourceMapping) {
+    this.projectId = projectId;
+    this.prefix = prefix;
+    this.resourceAttributeFilter = resourceAttributeFilter;
+    this.monitoredResourceMapping = monitoredResourceMapping;
   }
 
   @Override
@@ -135,7 +150,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     return TimeSeries.newBuilder()
         .setMetric(mapMetric(attributes, descriptor.getType()))
         .setMetricKind(descriptor.getMetricKind())
-        .setResource(mapResource(metric.getResource()));
+        .setResource(mapResource(metric.getResource(), monitoredResourceMapping));
   }
 
   private Attributes extraLabelsFromResource(Resource resource) {

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -68,7 +68,7 @@ class InternalMetricExporter implements MetricExporter {
   private final MetricDescriptorStrategy metricDescriptorStrategy;
   private final Predicate<AttributeKey<?>> resourceAttributesFilter;
   private final boolean useCreateServiceTimeSeries;
-  private final MonitoredResourceMapping monitoredResourceMapping;
+  private final MonitoredResourceDescription monitoredResourceDescription;
 
   InternalMetricExporter(
       String projectId,
@@ -77,14 +77,14 @@ class InternalMetricExporter implements MetricExporter {
       MetricDescriptorStrategy descriptorStrategy,
       Predicate<AttributeKey<?>> resourceAttributesFilter,
       boolean useCreateServiceTimeSeries,
-      MonitoredResourceMapping monitoredResourceMapping) {
+      MonitoredResourceDescription monitoredResourceDescription) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.metricServiceClient = client;
     this.metricDescriptorStrategy = descriptorStrategy;
     this.resourceAttributesFilter = resourceAttributesFilter;
     this.useCreateServiceTimeSeries = useCreateServiceTimeSeries;
-    this.monitoredResourceMapping = monitoredResourceMapping;
+    this.monitoredResourceDescription = monitoredResourceDescription;
   }
 
   static InternalMetricExporter createWithConfiguration(MetricConfiguration configuration)
@@ -124,7 +124,7 @@ class InternalMetricExporter implements MetricExporter {
         configuration.getDescriptorStrategy(),
         configuration.getResourceAttributesFilter(),
         configuration.getUseServiceTimeSeries(),
-        configuration.getMonitoredResourceMapping());
+        configuration.getMonitoredResourceDescription());
   }
 
   @VisibleForTesting
@@ -135,7 +135,7 @@ class InternalMetricExporter implements MetricExporter {
       MetricDescriptorStrategy descriptorStrategy,
       Predicate<AttributeKey<?>> resourceAttributesFilter,
       boolean useCreateServiceTimeSeries,
-      MonitoredResourceMapping monitoredResourceMapping) {
+      MonitoredResourceDescription monitoredResourceDescription) {
     return new InternalMetricExporter(
         projectId,
         prefix,
@@ -143,7 +143,7 @@ class InternalMetricExporter implements MetricExporter {
         descriptorStrategy,
         resourceAttributesFilter,
         useCreateServiceTimeSeries,
-        monitoredResourceMapping);
+        monitoredResourceDescription);
   }
 
   private void exportDescriptor(MetricDescriptor descriptor) {
@@ -168,7 +168,7 @@ class InternalMetricExporter implements MetricExporter {
     // 3. Fire the set of time series off.
     MetricTimeSeriesBuilder builder =
         new AggregateByLabelMetricTimeSeriesBuilder(
-            projectId, prefix, resourceAttributesFilter, monitoredResourceMapping);
+            projectId, prefix, resourceAttributesFilter, monitoredResourceDescription);
     for (final MetricData metricData : metrics) {
       // Extract all the underlying points.
       switch (metricData.getType()) {

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -46,7 +46,7 @@ public abstract class MetricConfiguration {
   /** Resource attribute filter that disables addition of resource attributes to metric labels. */
   public static final Predicate<AttributeKey<?>> NO_RESOURCE_ATTRIBUTES = attributeKey -> false;
 
-  public static final MonitoredResourceDescription DEFAULT_MONITORED_RESOURCE_DESCRIPTION =
+  public static final MonitoredResourceDescription EMPTY_MONITORED_RESOURCE_DESCRIPTION =
       new MonitoredResourceDescription("", Collections.emptySet());
 
   /**
@@ -160,8 +160,8 @@ public abstract class MetricConfiguration {
    * {@link io.opentelemetry.sdk.resources.Resource} to Google specific {@link
    * com.google.api.MonitoredResource}.
    *
-   * <p>This returns the {@link MetricConfiguration#DEFAULT_MONITORED_RESOURCE_DESCRIPTION} if not
-   * set through exporter configuration.
+   * <p>This returns the {@link MetricConfiguration#EMPTY_MONITORED_RESOURCE_DESCRIPTION} if not set
+   * through exporter configuration.
    *
    * @return The {@link MonitoredResourceDescription} object containing the MonitoredResource type
    *     and its expected labels.
@@ -193,7 +193,7 @@ public abstract class MetricConfiguration {
         .setInsecureEndpoint(false)
         .setUseServiceTimeSeries(false)
         .setResourceAttributesFilter(DEFAULT_RESOURCE_ATTRIBUTES_FILTER)
-        .setMonitoredResourceDescription(DEFAULT_MONITORED_RESOURCE_DESCRIPTION)
+        .setMonitoredResourceDescription(EMPTY_MONITORED_RESOURCE_DESCRIPTION)
         .setMetricServiceEndpoint(MetricServiceStubSettings.getDefaultEndpoint());
   }
 

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -28,6 +28,7 @@ import com.google.common.base.Suppliers;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -44,6 +45,9 @@ import javax.annotation.concurrent.Immutable;
 public abstract class MetricConfiguration {
   /** Resource attribute filter that disables addition of resource attributes to metric labels. */
   public static final Predicate<AttributeKey<?>> NO_RESOURCE_ATTRIBUTES = attributeKey -> false;
+
+  public static final MonitoredResourceMapping DEFAULT_RESOURCE_MAPPING =
+      new MonitoredResourceMapping("", Collections.emptySet());
 
   /**
    * Default resource attribute filter that adds recommended resource attributes to metric labels.
@@ -151,6 +155,19 @@ public abstract class MetricConfiguration {
    */
   public abstract boolean getUseServiceTimeSeries();
 
+  /**
+   * Returns the custom {@link MonitoredResourceMapping} that is used to map the OpenTelemetry
+   * {@link io.opentelemetry.sdk.resources.Resource} to Google specific {@link
+   * com.google.api.MonitoredResource}.
+   *
+   * <p>This returns the {@link MetricConfiguration#DEFAULT_RESOURCE_MAPPING} if not set through
+   * exporter configuration.
+   *
+   * @return The {@link MonitoredResourceMapping} object containing mapping between
+   *     MonitoredResource type and the expected labels.
+   */
+  public abstract MonitoredResourceMapping getMonitoredResourceMapping();
+
   @VisibleForTesting
   abstract boolean getInsecureEndpoint();
 
@@ -176,6 +193,7 @@ public abstract class MetricConfiguration {
         .setInsecureEndpoint(false)
         .setUseServiceTimeSeries(false)
         .setResourceAttributesFilter(DEFAULT_RESOURCE_ATTRIBUTES_FILTER)
+        .setMonitoredResourceMapping(DEFAULT_RESOURCE_MAPPING)
         .setMetricServiceEndpoint(MetricServiceStubSettings.getDefaultEndpoint());
   }
 
@@ -237,6 +255,19 @@ public abstract class MetricConfiguration {
      * @return this
      */
     public abstract Builder setUseServiceTimeSeries(boolean useServiceTimeSeries);
+
+    /**
+     * Sets the {@link MonitoredResourceMapping} that is used to map OpenTelemetry {@link
+     * io.opentelemetry.sdk.resources.Resource}s to Google specific {@link
+     * com.google.api.MonitoredResource}s.
+     *
+     * @param monitoredResourceMapping the {@link MonitoredResourceMapping} object responsible for
+     *     providing mapping between the custom {@link com.google.api.MonitoredResource} and the
+     *     expected labels.
+     * @return this.
+     */
+    public abstract Builder setMonitoredResourceMapping(
+        MonitoredResourceMapping monitoredResourceMapping);
 
     /**
      * Set a filter to determine which resource attributes to add to metrics as metric labels. By

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -46,8 +46,8 @@ public abstract class MetricConfiguration {
   /** Resource attribute filter that disables addition of resource attributes to metric labels. */
   public static final Predicate<AttributeKey<?>> NO_RESOURCE_ATTRIBUTES = attributeKey -> false;
 
-  public static final MonitoredResourceMapping DEFAULT_RESOURCE_MAPPING =
-      new MonitoredResourceMapping("", Collections.emptySet());
+  public static final MonitoredResourceDescription DEFAULT_MONITORED_RESOURCE_DESCRIPTION =
+      new MonitoredResourceDescription("", Collections.emptySet());
 
   /**
    * Default resource attribute filter that adds recommended resource attributes to metric labels.
@@ -156,17 +156,17 @@ public abstract class MetricConfiguration {
   public abstract boolean getUseServiceTimeSeries();
 
   /**
-   * Returns the custom {@link MonitoredResourceMapping} that is used to map the OpenTelemetry
+   * Returns the custom {@link MonitoredResourceDescription} that is used to map the OpenTelemetry
    * {@link io.opentelemetry.sdk.resources.Resource} to Google specific {@link
    * com.google.api.MonitoredResource}.
    *
-   * <p>This returns the {@link MetricConfiguration#DEFAULT_RESOURCE_MAPPING} if not set through
-   * exporter configuration.
+   * <p>This returns the {@link MetricConfiguration#DEFAULT_MONITORED_RESOURCE_DESCRIPTION} if not
+   * set through exporter configuration.
    *
-   * @return The {@link MonitoredResourceMapping} object containing mapping between
-   *     MonitoredResource type and the expected labels.
+   * @return The {@link MonitoredResourceDescription} object containing the MonitoredResource type
+   *     and its expected labels.
    */
-  public abstract MonitoredResourceMapping getMonitoredResourceMapping();
+  public abstract MonitoredResourceDescription getMonitoredResourceDescription();
 
   @VisibleForTesting
   abstract boolean getInsecureEndpoint();
@@ -193,7 +193,7 @@ public abstract class MetricConfiguration {
         .setInsecureEndpoint(false)
         .setUseServiceTimeSeries(false)
         .setResourceAttributesFilter(DEFAULT_RESOURCE_ATTRIBUTES_FILTER)
-        .setMonitoredResourceMapping(DEFAULT_RESOURCE_MAPPING)
+        .setMonitoredResourceDescription(DEFAULT_MONITORED_RESOURCE_DESCRIPTION)
         .setMetricServiceEndpoint(MetricServiceStubSettings.getDefaultEndpoint());
   }
 
@@ -257,17 +257,17 @@ public abstract class MetricConfiguration {
     public abstract Builder setUseServiceTimeSeries(boolean useServiceTimeSeries);
 
     /**
-     * Sets the {@link MonitoredResourceMapping} that is used to map OpenTelemetry {@link
+     * Sets the {@link MonitoredResourceDescription} that is used to map OpenTelemetry {@link
      * io.opentelemetry.sdk.resources.Resource}s to Google specific {@link
      * com.google.api.MonitoredResource}s.
      *
-     * @param monitoredResourceMapping the {@link MonitoredResourceMapping} object responsible for
-     *     providing mapping between the custom {@link com.google.api.MonitoredResource} and the
-     *     expected labels.
+     * @param monitoredResourceDescription the {@link MonitoredResourceDescription} object
+     *     responsible for providing mapping between the custom {@link
+     *     com.google.api.MonitoredResource} and the expected labels.
      * @return this.
      */
-    public abstract Builder setMonitoredResourceMapping(
-        MonitoredResourceMapping monitoredResourceMapping);
+    public abstract Builder setMonitoredResourceDescription(
+        MonitoredResourceDescription monitoredResourceDescription);
 
     /**
      * Set a filter to determine which resource attributes to add to metrics as metric labels. By

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
@@ -36,7 +36,7 @@ public final class MonitoredResourceDescription {
    */
   public MonitoredResourceDescription(String mrType, Set<String> mrLabels) {
     this.mrType = mrType;
-    this.mrLabels = mrLabels;
+    this.mrLabels = Collections.unmodifiableSet(mrLabels);
   }
 
   /**
@@ -45,7 +45,7 @@ public final class MonitoredResourceDescription {
    * @return Immutable set of labels that map to the specified monitored resource type.
    */
   public Set<String> getMonitoredResourceLabels() {
-    return Collections.unmodifiableSet(mrLabels);
+    return mrLabels;
   }
 
   /**

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.opentelemetry.metric;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Set;
-import javax.annotation.concurrent.Immutable;
 
 /**
  * This class holds the mapping between Google Cloud's monitored resource type and the labels for
@@ -54,6 +54,6 @@ public final class MonitoredResourceDescription {
    * @return The type of the monitored resource.
    */
   public String getMonitoredResourceType() {
-    return this.mrType;
+    return mrType;
   }
 }

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.opentelemetry.metric;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * This class holds the mapping between Google Cloud's monitored resource type and the labels for

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceDescription.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.Immutable;
  * identifying the given monitored resource type.
  */
 @Immutable
-public final class MonitoredResourceMapping {
+public final class MonitoredResourceDescription {
   private final String mrType;
   private final Set<String> mrLabels;
 
@@ -34,7 +34,7 @@ public final class MonitoredResourceMapping {
    * @param mrType The monitored resource type for which the mapping is being specified.
    * @param mrLabels A set of labels which uniquely identify a given monitored resource.
    */
-  public MonitoredResourceMapping(String mrType, Set<String> mrLabels) {
+  public MonitoredResourceDescription(String mrType, Set<String> mrLabels) {
     this.mrType = mrType;
     this.mrLabels = mrLabels;
   }

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceMapping.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceMapping.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.metric;
+
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class MonitoredResourceMapping {
+  private final String mrType;
+  private final Set<String> mrLabels;
+
+  public MonitoredResourceMapping(String mrType, Set<String> mrLabels) {
+    this.mrType = mrType;
+    this.mrLabels = mrLabels;
+  }
+
+  public Set<String> getMonitoredResourceLabels() {
+    return Collections.unmodifiableSet(mrLabels);
+  }
+
+  public String getMonitoredResourceType() {
+    return this.mrType;
+  }
+}

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceMapping.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MonitoredResourceMapping.java
@@ -19,20 +19,40 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * This class holds the mapping between Google Cloud's monitored resource type and the labels for
+ * identifying the given monitored resource type.
+ */
 @Immutable
 public final class MonitoredResourceMapping {
   private final String mrType;
   private final Set<String> mrLabels;
 
+  /**
+   * Public constructor.
+   *
+   * @param mrType The monitored resource type for which the mapping is being specified.
+   * @param mrLabels A set of labels which uniquely identify a given monitored resource.
+   */
   public MonitoredResourceMapping(String mrType, Set<String> mrLabels) {
     this.mrType = mrType;
     this.mrLabels = mrLabels;
   }
 
+  /**
+   * Returns the set of labels used to identify the monitored resource represented in this mapping.
+   *
+   * @return Immutable set of labels that map to the specified monitored resource type.
+   */
   public Set<String> getMonitoredResourceLabels() {
     return Collections.unmodifiableSet(mrLabels);
   }
 
+  /**
+   * The type of the monitored resource for which mapping is defined.
+   *
+   * @return The type of the monitored resource.
+   */
   public String getMonitoredResourceType() {
     return this.mrType;
   }

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -52,7 +52,7 @@ public class ResourceTranslator {
    * @param mrDescription The {@link MonitoredResourceDescription} in case the OpenTelemetry SDK
    *     {@link Resource} needs to be converted to a custom {@link MonitoredResource}. For use-cases
    *     not requiring custom {@link MonitoredResource}s, use the {@link
-   *     MetricConfiguration#DEFAULT_MONITORED_RESOURCE_DESCRIPTION}.
+   *     MetricConfiguration#EMPTY_MONITORED_RESOURCE_DESCRIPTION}.
    * @return The converted {@link MonitoredResource} based on the provided {@link
    *     MonitoredResourceDescription}.
    */

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -20,14 +20,12 @@ import com.google.cloud.opentelemetry.resource.GcpResource;
 import com.google.common.base.Strings;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 
 /** Translates from OpenTelemetry Resource into Google Cloud Monitoring's MonitoredResource. */
 public class ResourceTranslator {
   private static final String CUSTOM_MR_KEY = "gcp.resource_type";
-  private static final String BLANK_STRING = " ";
   private static final Logger LOGGER =
       Logger.getLogger(ResourceTranslator.class.getCanonicalName());
 
@@ -82,7 +80,10 @@ public class ResourceTranslator {
     expectedMRLabels.forEach(
         expectedLabel -> {
           String foundValue = resource.getAttribute(AttributeKey.stringKey(expectedLabel));
-          mr.putLabels(expectedLabel, Objects.requireNonNullElse(foundValue, BLANK_STRING));
+          if (foundValue != null) {
+            // only put labels for found value
+            mr.putLabels(expectedLabel, foundValue);
+          }
         });
     return mr.build();
   }

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -17,14 +17,64 @@ package com.google.cloud.opentelemetry.metric;
 
 import com.google.api.MonitoredResource;
 import com.google.cloud.opentelemetry.resource.GcpResource;
+import com.google.common.base.Strings;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Set;
 
 /** Translates from OpenTelemetry Resource into Google Cloud Monitoring's MonitoredResource. */
 public class ResourceTranslator {
+  private static final String CUSTOM_MR_KEY = "gcp.resource_type";
+  private static final String MAPPING_MISMATCH_EXCEPTION_MSG =
+      String.format(
+          "Found %s key, but the OpenTelemetry Resource either does not have the expected attributes indicated by the MonitoredResource mappings or has extra attributes.",
+          CUSTOM_MR_KEY);
+
   private ResourceTranslator() {}
 
   /** Converts a Java OpenTelemetry SDK resource into a MonitoredResource from GCP. */
+  @Deprecated
   public static MonitoredResource mapResource(Resource resource) {
+    GcpResource gcpResource =
+        com.google.cloud.opentelemetry.resource.ResourceTranslator.mapResource(resource);
+    MonitoredResource.Builder mr = MonitoredResource.newBuilder();
+    mr.setType(gcpResource.getResourceType());
+    gcpResource.getResourceLabels().getLabels().forEach(mr::putLabels);
+    return mr.build();
+  }
+
+  static MonitoredResource mapResource(Resource resource, MonitoredResourceMapping mrMappings) {
+    String mrTypeToMap = resource.getAttributes().get(AttributeKey.stringKey(CUSTOM_MR_KEY));
+    if (!Strings.isNullOrEmpty(mrTypeToMap)) {
+      return mapResourceUsingCustomMappings(resource, mrTypeToMap, mrMappings);
+    } else {
+      return mapResourceUsingStandardMappings(resource);
+    }
+  }
+
+  private static MonitoredResource mapResourceUsingCustomMappings(
+      Resource resource, String mrTypeToMap, MonitoredResourceMapping monitoredResourceMapping) {
+    if (!mrTypeToMap.equals(monitoredResourceMapping.getMonitoredResourceType())
+        || resource.getAttributes().size()
+            != monitoredResourceMapping.getMonitoredResourceLabels().size()) {
+      throw new RuntimeException(MAPPING_MISMATCH_EXCEPTION_MSG);
+    }
+    Set<String> mrLabels = monitoredResourceMapping.getMonitoredResourceLabels();
+    MonitoredResource.Builder mr = MonitoredResource.newBuilder();
+    mr.setType(mrTypeToMap);
+    mrLabels.forEach(
+        expectedLabel -> {
+          String foundValue = resource.getAttributes().get(AttributeKey.stringKey(expectedLabel));
+          if (foundValue != null) {
+            mr.putLabels(expectedLabel, foundValue);
+          } else {
+            throw new RuntimeException(MAPPING_MISMATCH_EXCEPTION_MSG);
+          }
+        });
+    return mr.build();
+  }
+
+  private static MonitoredResource mapResourceUsingStandardMappings(Resource resource) {
     GcpResource gcpResource =
         com.google.cloud.opentelemetry.resource.ResourceTranslator.mapResource(resource);
     MonitoredResource.Builder mr = MonitoredResource.newBuilder();

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -41,12 +41,25 @@ public class ResourceTranslator {
     return mr.build();
   }
 
-  static MonitoredResource mapResource(Resource resource, MonitoredResourceDescription mrMappings) {
+  /**
+   * Converts a Java OpenTelemetry SDK {@link Resource} into a Google specific {@link
+   * MonitoredResource}.
+   *
+   * @param resource The OpenTelemetry {@link Resource} to be converted.
+   * @param mrDescription The {@link MonitoredResourceDescription} in case the OpenTelemetry SDK
+   *     {@link Resource} needs to be converted to a custom {@link MonitoredResource}. For use-cases
+   *     not requiring custom {@link MonitoredResource}s, use the {@link
+   *     MetricConfiguration#DEFAULT_MONITORED_RESOURCE_DESCRIPTION}.
+   * @return The converted {@link MonitoredResource} based on the provided {@link
+   *     MonitoredResourceDescription}.
+   */
+  static MonitoredResource mapResource(
+      Resource resource, MonitoredResourceDescription mrDescription) {
     String mrTypeToMap = resource.getAttributes().get(AttributeKey.stringKey(CUSTOM_MR_KEY));
     if (Strings.isNullOrEmpty(mrTypeToMap)) {
       return mapResourceUsingCustomerMappings(resource);
     } else {
-      return mapResourceUsingPlatformMappings(resource, mrTypeToMap, mrMappings);
+      return mapResourceUsingPlatformMappings(resource, mrTypeToMap, mrDescription);
     }
   }
 

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/ResourceTranslator.java
@@ -20,15 +20,13 @@ import com.google.cloud.opentelemetry.resource.GcpResource;
 import com.google.common.base.Strings;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Objects;
 import java.util.Set;
 
 /** Translates from OpenTelemetry Resource into Google Cloud Monitoring's MonitoredResource. */
 public class ResourceTranslator {
   private static final String CUSTOM_MR_KEY = "gcp.resource_type";
-  private static final String MAPPING_MISMATCH_EXCEPTION_MSG =
-      String.format(
-          "Found %s key, but the OpenTelemetry Resource either does not have the expected attributes indicated by the MonitoredResource mappings or has extra attributes.",
-          CUSTOM_MR_KEY);
+  private static final String BLANK_STRING = " ";
 
   private ResourceTranslator() {}
 
@@ -43,38 +41,31 @@ public class ResourceTranslator {
     return mr.build();
   }
 
-  static MonitoredResource mapResource(Resource resource, MonitoredResourceMapping mrMappings) {
+  static MonitoredResource mapResource(Resource resource, MonitoredResourceDescription mrMappings) {
     String mrTypeToMap = resource.getAttributes().get(AttributeKey.stringKey(CUSTOM_MR_KEY));
-    if (!Strings.isNullOrEmpty(mrTypeToMap)) {
-      return mapResourceUsingCustomMappings(resource, mrTypeToMap, mrMappings);
+    if (Strings.isNullOrEmpty(mrTypeToMap)) {
+      return mapResourceUsingCustomerMappings(resource);
     } else {
-      return mapResourceUsingStandardMappings(resource);
+      return mapResourceUsingPlatformMappings(resource, mrTypeToMap, mrMappings);
     }
   }
 
-  private static MonitoredResource mapResourceUsingCustomMappings(
-      Resource resource, String mrTypeToMap, MonitoredResourceMapping monitoredResourceMapping) {
-    if (!mrTypeToMap.equals(monitoredResourceMapping.getMonitoredResourceType())
-        || resource.getAttributes().size()
-            != monitoredResourceMapping.getMonitoredResourceLabels().size()) {
-      throw new RuntimeException(MAPPING_MISMATCH_EXCEPTION_MSG);
-    }
-    Set<String> mrLabels = monitoredResourceMapping.getMonitoredResourceLabels();
+  private static MonitoredResource mapResourceUsingPlatformMappings(
+      Resource resource,
+      String mrTypeToMap,
+      MonitoredResourceDescription monitoredResourceDescription) {
+    Set<String> expectedMRLabels = monitoredResourceDescription.getMonitoredResourceLabels();
     MonitoredResource.Builder mr = MonitoredResource.newBuilder();
     mr.setType(mrTypeToMap);
-    mrLabels.forEach(
+    expectedMRLabels.forEach(
         expectedLabel -> {
-          String foundValue = resource.getAttributes().get(AttributeKey.stringKey(expectedLabel));
-          if (foundValue != null) {
-            mr.putLabels(expectedLabel, foundValue);
-          } else {
-            throw new RuntimeException(MAPPING_MISMATCH_EXCEPTION_MSG);
-          }
+          String foundValue = resource.getAttribute(AttributeKey.stringKey(expectedLabel));
+          mr.putLabels(expectedLabel, Objects.requireNonNullElse(foundValue, BLANK_STRING));
         });
     return mr.build();
   }
 
-  private static MonitoredResource mapResourceUsingStandardMappings(Resource resource) {
+  private static MonitoredResource mapResourceUsingCustomerMappings(Resource resource) {
     GcpResource gcpResource =
         com.google.cloud.opentelemetry.resource.ResourceTranslator.mapResource(resource);
     MonitoredResource.Builder mr = MonitoredResource.newBuilder();

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -63,10 +63,11 @@ public class FakeData {
 
   static final Attributes someCustomMRAttributes =
       Attributes.builder()
+          .put("gcp.resource_type", "custom_mr_instance") // required to trigger platform mapping
           .put("host_id", aHostId)
           .put("location", aCloudZone)
           .put("service_instance_id", "test-gcs-service-id")
-          .put("gcp.resource_type", "custom_mr_instance")
+          .put("foo", "bar") // extra label, gets ignored
           .build();
 
   static final Resource aCustomMonitoredResource = Resource.create(someCustomMRAttributes);

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -61,6 +61,16 @@ public class FakeData {
   static final Attributes someLabels =
       Attributes.builder().put("label1", "value1").put("label2", "False").build();
 
+  static final Attributes someCustomMRAttributes =
+      Attributes.builder()
+          .put("host_id", aHostId)
+          .put("location", aCloudZone)
+          .put("service_instance_id", "test-gcs-service-id")
+          .put("gcp.resource_type", "custom_mr_instance")
+          .build();
+
+  static final Resource aCustomMonitoredResource = Resource.create(someCustomMRAttributes);
+
   static final Attributes someGceAttributes =
       Attributes.builder()
           .put(
@@ -112,6 +122,16 @@ public class FakeData {
   static final MetricData aMetricData =
       ImmutableMetricData.createLongSum(
           aGceResource,
+          anInstrumentationLibraryInfo,
+          "opentelemetry/name",
+          "description",
+          "ns",
+          ImmutableSumData.create(
+              true, AggregationTemporality.CUMULATIVE, ImmutableList.of(aLongPoint)));
+
+  static final MetricData aMetricDataWithCustomResource =
+      ImmutableMetricData.createLongSum(
+          aCustomMonitoredResource,
           anInstrumentationLibraryInfo,
           "opentelemetry/name",
           "description",

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/FakeData.java
@@ -72,6 +72,9 @@ public class FakeData {
 
   static final Resource aCustomMonitoredResource = Resource.create(someCustomMRAttributes);
 
+  static final Resource aCustomMonitoredResourceWithNoAttributes =
+      Resource.create(Attributes.builder().put("gcp.resource_type", "custom_mr_instance").build());
+
   static final Attributes someGceAttributes =
       Attributes.builder()
           .put(
@@ -133,6 +136,16 @@ public class FakeData {
   static final MetricData aMetricDataWithCustomResource =
       ImmutableMetricData.createLongSum(
           aCustomMonitoredResource,
+          anInstrumentationLibraryInfo,
+          "opentelemetry/name",
+          "description",
+          "ns",
+          ImmutableSumData.create(
+              true, AggregationTemporality.CUMULATIVE, ImmutableList.of(aLongPoint)));
+
+  static final MetricData aMetricDataWithEmptyResourceAttributes =
+      ImmutableMetricData.createLongSum(
+          aCustomMonitoredResourceWithNoAttributes,
           anInstrumentationLibraryInfo,
           "opentelemetry/name",
           "description",

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -417,8 +417,7 @@ public class GoogleCloudMetricExporterTest {
   public void testExportWithMonitoredResourceMappingSucceeds() {
     MonitoredResourceDescription monitoredResourceDescription =
         new MonitoredResourceDescription(
-            "custom_mr_instance",
-            Set.of("service_instance_id", "gcp.resource_type", "host_id", "location"));
+            "custom_mr_instance", Set.of("service_instance_id", "host_id", "location"));
 
     // controls which resource attributes end up in metric labels
     Predicate<AttributeKey<?>> customAttributesFilter =
@@ -486,7 +485,6 @@ public class GoogleCloudMetricExporterTest {
                     .putLabels("service_instance_id", "test-gcs-service-id")
                     .putLabels("location", aCloudZone)
                     .putLabels("host_id", aHostId)
-                    .putLabels("gcp.resource_type", "custom_mr_instance")
                     .build())
             .build();
     CreateMetricDescriptorRequest expectedRequest =

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -26,6 +26,7 @@ import static com.google.cloud.opentelemetry.metric.FakeData.aHistogramPoint;
 import static com.google.cloud.opentelemetry.metric.FakeData.aHostId;
 import static com.google.cloud.opentelemetry.metric.FakeData.aLongPoint;
 import static com.google.cloud.opentelemetry.metric.FakeData.aMetricData;
+import static com.google.cloud.opentelemetry.metric.FakeData.aMetricDataWithCustomResource;
 import static com.google.cloud.opentelemetry.metric.FakeData.aProjectId;
 import static com.google.cloud.opentelemetry.metric.FakeData.aSpanId;
 import static com.google.cloud.opentelemetry.metric.FakeData.aTraceId;
@@ -72,6 +73,7 @@ import com.google.monitoring.v3.TypedValue;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -84,6 +86,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -408,6 +411,111 @@ public class GoogleCloudMetricExporterTest {
     verify(mockClient, times(0)).createTimeSeries(any(ProjectName.class), any());
 
     assertFalse(result.isSuccess());
+  }
+
+  @Test
+  public void testExportWithMonitoredResourceMappingSucceeds() {
+    MonitoredResourceMapping monitoredResourceMapping =
+        new MonitoredResourceMapping(
+            "custom_mr_instance",
+            Set.of("service_instance_id", "gcp.resource_type", "host_id", "location"));
+
+    // controls which resource attributes end up in metric labels
+    Predicate<AttributeKey<?>> customAttributesFilter =
+        attributeKey ->
+            !attributeKey.getKey().isEmpty() && attributeKey.getKey().equals("service_instance_id");
+
+    MetricDescriptor expectedDescriptor =
+        MetricDescriptor.newBuilder()
+            .setDisplayName(aMetricDataWithCustomResource.getName())
+            .setType(DEFAULT_PREFIX + "/" + aMetricDataWithCustomResource.getName())
+            .addLabels(
+                LabelDescriptor.newBuilder()
+                    .setKey("service_instance_id")
+                    .setValueType(ValueType.STRING)
+                    .build())
+            .addLabels(
+                LabelDescriptor.newBuilder()
+                    .setKey("label1")
+                    .setValueType(ValueType.STRING)
+                    .build())
+            .addLabels(
+                LabelDescriptor.newBuilder()
+                    .setKey("label2")
+                    .setValueType(ValueType.STRING)
+                    .build())
+            .setMetricKind(MetricKind.CUMULATIVE)
+            .setValueType(MetricDescriptor.ValueType.INT64)
+            .setUnit(METRIC_DESCRIPTOR_TIME_UNIT)
+            .setDescription(aMetricDataWithCustomResource.getDescription())
+            .build();
+    TimeInterval expectedTimeInterval =
+        TimeInterval.newBuilder()
+            .setStartTime(
+                Timestamp.newBuilder()
+                    .setSeconds(aLongPoint.getStartEpochNanos() / NANO_PER_SECOND)
+                    .setNanos(0)
+                    .build())
+            .setEndTime(
+                Timestamp.newBuilder()
+                    .setSeconds(aLongPoint.getEpochNanos() / NANO_PER_SECOND)
+                    .setNanos(0)
+                    .build())
+            .build();
+    Point expectedPoint =
+        Point.newBuilder()
+            .setValue(TypedValue.newBuilder().setInt64Value(aLongPoint.getValue()))
+            .setInterval(expectedTimeInterval)
+            .build();
+    TimeSeries expectedTimeSeries =
+        TimeSeries.newBuilder()
+            .setMetric(
+                Metric.newBuilder()
+                    .setType(expectedDescriptor.getType())
+                    .putLabels("service_instance_id", "test-gcs-service-id")
+                    .putLabels("label1", "value1")
+                    .putLabels("label2", "false")
+                    .putLabels(LABEL_INSTRUMENTATION_SOURCE, "instrumentName")
+                    .putLabels(LABEL_INSTRUMENTATION_VERSION, "0")
+                    .build())
+            .addPoints(expectedPoint)
+            .setMetricKind(expectedDescriptor.getMetricKind())
+            .setResource(
+                MonitoredResource.newBuilder()
+                    .setType("custom_mr_instance")
+                    .putLabels("service_instance_id", "test-gcs-service-id")
+                    .putLabels("location", aCloudZone)
+                    .putLabels("host_id", aHostId)
+                    .putLabels("gcp.resource_type", "custom_mr_instance")
+                    .build())
+            .build();
+    CreateMetricDescriptorRequest expectedRequest =
+        CreateMetricDescriptorRequest.newBuilder()
+            .setName("projects/" + aProjectId)
+            .setMetricDescriptor(expectedDescriptor)
+            .build();
+    ProjectName expectedProjectName = ProjectName.of(aProjectId);
+
+    MetricExporter exporter =
+        InternalMetricExporter.createWithClient(
+            aProjectId,
+            DEFAULT_PREFIX,
+            mockClient,
+            MetricDescriptorStrategy.ALWAYS_SEND,
+            customAttributesFilter,
+            false,
+            monitoredResourceMapping);
+
+    CompletableResultCode result = exporter.export(ImmutableList.of(aMetricDataWithCustomResource));
+    verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
+    verify(mockClient, times(1))
+        .createTimeSeries(projectNameArgCaptor.capture(), timeSeriesArgCaptor.capture());
+
+    assertTrue(result.isSuccess());
+    assertEquals(expectedRequest, metricDescriptorCaptor.getValue());
+    assertEquals(expectedProjectName, projectNameArgCaptor.getValue());
+    assertEquals(1, timeSeriesArgCaptor.getValue().size());
+    assertEquals(expectedTimeSeries, timeSeriesArgCaptor.getValue().get(0));
   }
 
   @Test

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -674,13 +674,7 @@ public class GoogleCloudMetricExporterTest {
                     .build())
             .addPoints(expectedPoint)
             .setMetricKind(expectedDescriptor.getMetricKind())
-            .setResource(
-                MonitoredResource.newBuilder()
-                    .setType("custom_mr_instance")
-                    .putLabels("service_instance_id", " ")
-                    .putLabels("location", " ")
-                    .putLabels("host_id", " ")
-                    .build())
+            .setResource(MonitoredResource.newBuilder().setType("custom_mr_instance").build())
             .build();
     CreateMetricDescriptorRequest expectedRequest =
         CreateMetricDescriptorRequest.newBuilder()

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -33,9 +33,9 @@ import static com.google.cloud.opentelemetry.metric.FakeData.aSpanId;
 import static com.google.cloud.opentelemetry.metric.FakeData.aTraceId;
 import static com.google.cloud.opentelemetry.metric.FakeData.anInstrumentationLibraryInfo;
 import static com.google.cloud.opentelemetry.metric.FakeData.googleComputeServiceMetricData;
-import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_PREFIX;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_RESOURCE_ATTRIBUTES_FILTER;
+import static com.google.cloud.opentelemetry.metric.MetricConfiguration.EMPTY_MONITORED_RESOURCE_DESCRIPTION;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.METRIC_DESCRIPTOR_TIME_UNIT;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.NANO_PER_SECOND;
@@ -140,7 +140,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.SEND_ONCE,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
     assertTrue(result.isSuccess());
     CompletableResultCode result2 = exporter.export(ImmutableList.of(aMetricData, aHistogram));
@@ -251,7 +251,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -374,7 +374,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
     CompletableResultCode result = exporter.export(ImmutableList.of(aHistogram));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
     verify(mockClient, times(1))
@@ -396,7 +396,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             false,
-            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
 
     MetricData metricData =
         ImmutableMetricData.createDoubleSummary(
@@ -774,7 +774,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             true,
-            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
 
     CompletableResultCode result =
         exporter.export(ImmutableList.of(googleComputeServiceMetricData));

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -33,6 +33,7 @@ import static com.google.cloud.opentelemetry.metric.FakeData.anInstrumentationLi
 import static com.google.cloud.opentelemetry.metric.FakeData.googleComputeServiceMetricData;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_PREFIX;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_RESOURCE_ATTRIBUTES_FILTER;
+import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.METRIC_DESCRIPTOR_TIME_UNIT;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.NANO_PER_SECOND;
@@ -134,7 +135,8 @@ public class GoogleCloudMetricExporterTest {
             mockClient,
             MetricDescriptorStrategy.SEND_ONCE,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
-            false);
+            false,
+            DEFAULT_RESOURCE_MAPPING);
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
     assertTrue(result.isSuccess());
     CompletableResultCode result2 = exporter.export(ImmutableList.of(aMetricData, aHistogram));
@@ -244,7 +246,8 @@ public class GoogleCloudMetricExporterTest {
             mockClient,
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
-            false);
+            false,
+            DEFAULT_RESOURCE_MAPPING);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -366,7 +369,8 @@ public class GoogleCloudMetricExporterTest {
             mockClient,
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
-            false);
+            false,
+            DEFAULT_RESOURCE_MAPPING);
     CompletableResultCode result = exporter.export(ImmutableList.of(aHistogram));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
     verify(mockClient, times(1))
@@ -387,7 +391,8 @@ public class GoogleCloudMetricExporterTest {
             mockClient,
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
-            false);
+            false,
+            DEFAULT_RESOURCE_MAPPING);
 
     MetricData metricData =
         ImmutableMetricData.createDoubleSummary(
@@ -466,7 +471,8 @@ public class GoogleCloudMetricExporterTest {
             mockClient,
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
-            true);
+            true,
+            DEFAULT_RESOURCE_MAPPING);
 
     CompletableResultCode result =
         exporter.export(ImmutableList.of(googleComputeServiceMetricData));

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -32,9 +32,9 @@ import static com.google.cloud.opentelemetry.metric.FakeData.aSpanId;
 import static com.google.cloud.opentelemetry.metric.FakeData.aTraceId;
 import static com.google.cloud.opentelemetry.metric.FakeData.anInstrumentationLibraryInfo;
 import static com.google.cloud.opentelemetry.metric.FakeData.googleComputeServiceMetricData;
+import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_MONITORED_RESOURCE_DESCRIPTION;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_PREFIX;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_RESOURCE_ATTRIBUTES_FILTER;
-import static com.google.cloud.opentelemetry.metric.MetricConfiguration.DEFAULT_RESOURCE_MAPPING;
 import static com.google.cloud.opentelemetry.metric.MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.METRIC_DESCRIPTOR_TIME_UNIT;
 import static com.google.cloud.opentelemetry.metric.MetricTranslator.NANO_PER_SECOND;
@@ -139,7 +139,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.SEND_ONCE,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_RESOURCE_MAPPING);
+            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
     assertTrue(result.isSuccess());
     CompletableResultCode result2 = exporter.export(ImmutableList.of(aMetricData, aHistogram));
@@ -250,7 +250,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_RESOURCE_MAPPING);
+            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -373,7 +373,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            DEFAULT_RESOURCE_MAPPING);
+            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
     CompletableResultCode result = exporter.export(ImmutableList.of(aHistogram));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
     verify(mockClient, times(1))
@@ -395,7 +395,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             false,
-            DEFAULT_RESOURCE_MAPPING);
+            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
 
     MetricData metricData =
         ImmutableMetricData.createDoubleSummary(
@@ -415,8 +415,8 @@ public class GoogleCloudMetricExporterTest {
 
   @Test
   public void testExportWithMonitoredResourceMappingSucceeds() {
-    MonitoredResourceMapping monitoredResourceMapping =
-        new MonitoredResourceMapping(
+    MonitoredResourceDescription monitoredResourceDescription =
+        new MonitoredResourceDescription(
             "custom_mr_instance",
             Set.of("service_instance_id", "gcp.resource_type", "host_id", "location"));
 
@@ -504,7 +504,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             customAttributesFilter,
             false,
-            monitoredResourceMapping);
+            monitoredResourceDescription);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricDataWithCustomResource));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -580,7 +580,7 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             true,
-            DEFAULT_RESOURCE_MAPPING);
+            DEFAULT_MONITORED_RESOURCE_DESCRIPTION);
 
     CompletableResultCode result =
         exporter.export(ImmutableList.of(googleComputeServiceMetricData));

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.opentelemetry.metric;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import com.google.cloud.opentelemetry.metric.MetricConfiguration.Builder;
 import io.opentelemetry.api.common.AttributeKey;
 import java.time.Duration;
 import java.util.Date;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,22 +53,30 @@ public class MetricConfigurationTest {
     assertNull(configuration.getCredentials());
     assertEquals(PROJECT_ID, configuration.getProjectId());
     assertFalse(configuration.getUseServiceTimeSeries());
+    assertNotNull(configuration.getResourceAttributesFilter());
+    assertNotNull(configuration.getMonitoredResourceMapping());
   }
 
   @Test
   public void testSetAllConfigurationFieldsSucceeds() {
     Predicate<AttributeKey<?>> allowAllPredicate = attributeKey -> true;
+    MonitoredResourceMapping customMRMapping =
+        new MonitoredResourceMapping(
+            "custom_mr", Set.of("instance_id", "gcp.resource_type", "host_id"));
+
     MetricConfiguration configuration =
         MetricConfiguration.builder()
             .setProjectId(PROJECT_ID)
             .setCredentials(FAKE_CREDENTIALS)
             .setResourceAttributesFilter(allowAllPredicate)
+            .setMonitoredResourceMapping(customMRMapping)
             .setUseServiceTimeSeries(true)
             .build();
 
     assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
     assertEquals(PROJECT_ID, configuration.getProjectId());
     assertEquals(allowAllPredicate, configuration.getResourceAttributesFilter());
+    assertEquals(customMRMapping, configuration.getMonitoredResourceMapping());
     assertTrue(configuration.getUseServiceTimeSeries());
   }
 

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
@@ -61,8 +61,7 @@ public class MetricConfigurationTest {
   public void testSetAllConfigurationFieldsSucceeds() {
     Predicate<AttributeKey<?>> allowAllPredicate = attributeKey -> true;
     MonitoredResourceDescription customMRMapping =
-        new MonitoredResourceDescription(
-            "custom_mr", Set.of("instance_id", "gcp.resource_type", "host_id"));
+        new MonitoredResourceDescription("custom_mr", Set.of("instance_id", "foo_bar", "host_id"));
 
     MetricConfiguration configuration =
         MetricConfiguration.builder()

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
@@ -54,14 +54,14 @@ public class MetricConfigurationTest {
     assertEquals(PROJECT_ID, configuration.getProjectId());
     assertFalse(configuration.getUseServiceTimeSeries());
     assertNotNull(configuration.getResourceAttributesFilter());
-    assertNotNull(configuration.getMonitoredResourceMapping());
+    assertNotNull(configuration.getMonitoredResourceDescription());
   }
 
   @Test
   public void testSetAllConfigurationFieldsSucceeds() {
     Predicate<AttributeKey<?>> allowAllPredicate = attributeKey -> true;
-    MonitoredResourceMapping customMRMapping =
-        new MonitoredResourceMapping(
+    MonitoredResourceDescription customMRMapping =
+        new MonitoredResourceDescription(
             "custom_mr", Set.of("instance_id", "gcp.resource_type", "host_id"));
 
     MetricConfiguration configuration =
@@ -69,14 +69,14 @@ public class MetricConfigurationTest {
             .setProjectId(PROJECT_ID)
             .setCredentials(FAKE_CREDENTIALS)
             .setResourceAttributesFilter(allowAllPredicate)
-            .setMonitoredResourceMapping(customMRMapping)
+            .setMonitoredResourceDescription(customMRMapping)
             .setUseServiceTimeSeries(true)
             .build();
 
     assertEquals(FAKE_CREDENTIALS, configuration.getCredentials());
     assertEquals(PROJECT_ID, configuration.getProjectId());
     assertEquals(allowAllPredicate, configuration.getResourceAttributesFilter());
-    assertEquals(customMRMapping, configuration.getMonitoredResourceMapping());
+    assertEquals(customMRMapping, configuration.getMonitoredResourceDescription());
     assertTrue(configuration.getUseServiceTimeSeries());
   }
 


### PR DESCRIPTION
### Description 
Provides a configuration option for the metrics exporter allowing users to specify mappings for custom MonitoredResource type. 

The mapping logic for the custom MR type is activated based on the presence of `gcp.resource_type` resource attribute in the underlying OpenTelemetry resource.

Some methods were marked with `@Deprecated` but no breaking changes were made in this PR. 

#### Sample usage with the proposed changes

```java
  // MetricConfiguration object for the metrics exporter - 
  MetricConfiguration configuration =
        MetricConfiguration.builder()
            .setProjectId(PROJECT_ID)
            .setCredentials(CREDENTIALS)
            .setResourceAttributesFilter(allowAllPredicate)
            .setMonitoredResourceDescription(
                new MonitoredResourceDescription(
                    "custom_mr", Set.of("instance_id", "api", "host_id")))
            .setUseServiceTimeSeries(true)
            .build();
            
  // If the OTel resource now has the Attribute label `gcp.resource_type` with value 
  // `custom_mr` the exporter will attempt to map the OTel resource to the set MR type.
```

### Testing
 - Tested this newly added configuration with the existing metrics example.
 - Used the configuration to override MR type to dataflow-job.
 - The program returned valid error when all required labels were not present in the resource attributes.
 - When all required labels were present, metric was successfully written against the correct MR type.

###### Configuration code for reference
```java

// MeterProvider and OTel Resource setup
    MonitoredResourceDescription monitoredResourceDescription =
        new MonitoredResourceDescription(
            "dataflow_job", Set.of("job_name", "project_id", "region"));

    MetricExporter metricExporter =
        GoogleCloudMetricExporter.createWithConfiguration(
            MetricConfiguration.builder()
                .setMonitoredResourceDescription(monitoredResourceDescription)
                .build());

    // project_id inferred from env variables
    Attributes attrs =
        Attributes.builder()
            .put("gcp.resource_type", "dataflow_job") // required to trigger platform mapping
            .put("network_id", "random-id") // was ignored
            .put("job_name", "some-job")
            .put("region", "us1")
            .build();

    METER_PROVIDER =
        SdkMeterProvider.builder()
            .setResource(Resource.create(attrs))
            .registerMetricReader(
                PeriodicMetricReader.builder(metricExporter)
                    .setInterval(java.time.Duration.ofSeconds(30))
                    .build())
            .build();
  ...
  // Standard OpenTelemetry code to record metric
```