### PR TITLE
Make the trace flags optional when parsing x-cloud-trace-context

### DIFF
--- a/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
+++ b/propagators/gcp/src/main/java/com/google/cloud/opentelemetry/propagators/XCloudTraceContextPropagator.java
@@ -42,7 +42,7 @@ public final class XCloudTraceContextPropagator implements TextMapPropagator {
   private static final String FIELD = "x-cloud-trace-context";
   private static final Collection<String> FIELDS = Collections.singletonList(FIELD);
   private static final Pattern VALUE_PATTERN =
-      Pattern.compile("(?<traceid>[0-9a-f]{32})\\/(?<spanid>[\\d]{1,20});o=(?<sampled>\\d+)");
+      Pattern.compile("(?<traceid>[0-9a-f]{32})\\/(?<spanid>[\\d]{1,20})(;o=(?<sampled>\\d+))?");
   private static final Logger LOGGER =
       Logger.getLogger(XCloudTraceContextPropagator.class.getCanonicalName());
 

--- a/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
+++ b/propagators/gcp/src/test/java/com/google/cloud/opentelemetry/propagators/PropagatorTest.java
@@ -94,6 +94,22 @@ public class PropagatorTest {
   }
 
   @Test
+  public void testExtractWithoutTraceFlags() {
+    Context context = Context.root();
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("x-cloud-trace-context", "00000000000000000000000000000010/15");
+    TextMapPropagator propagator = new XCloudTraceContextPropagator(false);
+
+    // Now try to extract the value.
+    Context updated = propagator.extract(context, carrier, GETTER);
+    Span span = Span.fromContext(updated);
+    Assert.assertNotNull(span);
+    Assert.assertEquals("00000000000000000000000000000010", span.getSpanContext().getTraceId());
+    Assert.assertEquals("000000000000000f", span.getSpanContext().getSpanId());
+    Assert.assertEquals(false, span.getSpanContext().getTraceFlags().isSampled());
+  }
+
+  @Test
   public void testNotInjectOneway() {
     Span span =
         Span.wrap(


### PR DESCRIPTION
Hello guys,

I've observed that Cloud load balancing sends requests with `x-cloud-trace-context` that lack `o=<sampled>` to the backend service.
This is causing the propagator not properly to propagate the trace context.
I addressed this issue by making the trace flag optional.

Could someone look over this?

Ref: https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/167