### PR TITLE
Expose option to provide MetricServiceSettings in MetricConfiguration

### DIFF
--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -32,7 +32,11 @@ export GOOGLE_CLOUD_PROJECT="my-awesome-gcp-project-id"
 You can run the example application via gradle. From the project root:
 
 ```shell
+# Running with default exporter config
 cd examples/metrics/ && gradle run 
+
+# Running with custom exporter config
+cd examples/metrics/ && gradle run --args='--custom-config'
 ```
 
 #### Run the example as a Cloud Run Job

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.opentelemetry.metric;
 
+import static com.google.api.client.util.Preconditions.checkNotNull;
+
 import com.google.api.MetricDescriptor;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
@@ -39,18 +41,15 @@ import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-
-import static com.google.api.client.util.Preconditions.checkNotNull;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class encapsulates internal implementation details for exporting metrics to Google Cloud

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -44,6 +44,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,6 +60,7 @@ import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
 import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.MonitoredResource;
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
@@ -98,6 +101,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudMetricExporterTest {
@@ -120,7 +124,7 @@ public class GoogleCloudMetricExporterTest {
   }
 
   @Test
-  public void testCreateWithConfigurationSucceeds() throws IOException {
+  public void testCreateWithConfigurationSucceeds() {
     MetricConfiguration configuration =
         MetricConfiguration.builder()
             .setProjectId(aProjectId)
@@ -128,6 +132,54 @@ public class GoogleCloudMetricExporterTest {
             .build();
     MetricExporter exporter = GoogleCloudMetricExporter.createWithConfiguration(configuration);
     assertNotNull(exporter);
+  }
+
+  @Test
+  public void testCreateWithMetricServiceSettingExportSucceeds() throws IOException {
+    try (MockedStatic<MetricServiceClient> mockedServiceClientClass =
+        mockStatic(MetricServiceClient.class)) {
+      MetricServiceSettings.Builder builder = MetricServiceSettings.newBuilder();
+      builder
+          .setCredentialsProvider(FixedCredentialsProvider.create(aFakeCredential))
+          .setEndpoint(MetricConfiguration.DEFAULT_METRIC_SERVICE_ENDPOINT)
+          .createMetricDescriptorSettings()
+          .setSimpleTimeoutNoRetries(
+              Duration.ofMillis(MetricConfiguration.DEFAULT_DEADLINE.toMillis()));
+      MetricServiceSettings serviceSettings = builder.build();
+
+      MetricConfiguration configuration =
+          MetricConfiguration.builder()
+              .setProjectId(aProjectId)
+              .setMetricServiceEndpoint("https://fake-endpoint")
+              .setInsecureEndpoint(true)
+              .setCredentials(null)
+              .setMetricServiceSettings(serviceSettings)
+              .setDescriptorStrategy(MetricDescriptorStrategy.SEND_ONCE)
+              .build();
+      assertNotNull(configuration.getMetricServiceSettings());
+
+      // Mock the static method to create a MetricServiceClient to return a mocked object
+      mockedServiceClientClass
+          .when(() -> MetricServiceClient.create(eq(configuration.getMetricServiceSettings())))
+          .thenReturn(mockMetricServiceClient);
+
+      MetricExporter exporter = InternalMetricExporter.createWithConfiguration(configuration);
+      assertNotNull(exporter);
+
+      // verify that the MetricServiceClient used in the exporter was created using the
+      // MetricServiceSettings provided in configuration
+      mockedServiceClientClass.verify(
+          times(1), () -> MetricServiceClient.create(eq(configuration.getMetricServiceSettings())));
+
+      // verify that export operation on the resulting exporter can still be called
+      CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
+      assertTrue(result.isSuccess());
+
+      // verify that the CreateTimeseries call was invoked on the client generated from the supplied
+      // MetricServiceSettings object
+      verify(mockMetricServiceClient, times(1))
+          .createTimeSeries(projectNameArgCaptor.capture(), timeSeriesArgCaptor.capture());
+    }
   }
 
   @Test


### PR DESCRIPTION
#### Description
This PR adds a configuration option to the `MetricConfiguration` that allows the user to configure the underlying instance of `MetricServiceClient` which is used by the exporter to interact with the Cloud Monitoring API.

This feature is intended for advanced use-cases only.

#### Testing
 - Added unit tests pass.
 - Updated the metrics sample to demonstrate a use-case for the `setMetricServiceSettings` function.

fixes. #149 