### PR TITLE
Add config option to disable attaching InstrumentationLibrary labels

### DIFF
--- a/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
+++ b/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
@@ -70,6 +70,7 @@ public class MetricsExporterExample {
     // Any properties not set would be retrieved from the default configuration of the exporter.
     return MetricConfiguration.builder()
         .setMetricServiceSettings(metricServiceSettingsBuilder.build())
+        .setInstrumentationLibraryLabelsEnabled(false)
         .build();
   }
 

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/AggregateByLabelMetricTimeSeriesBuilder.java
@@ -60,6 +60,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
   private final String prefix;
   private final Predicate<AttributeKey<?>> resourceAttributeFilter;
   private final MonitoredResourceDescription monitoredResourceDescription;
+  private final boolean instrumentationLibraryLabelsEnabled;
 
   @Deprecated
   public AggregateByLabelMetricTimeSeriesBuilder(String projectId, String prefix) {
@@ -67,6 +68,7 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.prefix = prefix;
     this.resourceAttributeFilter = MetricConfiguration.NO_RESOURCE_ATTRIBUTES;
     this.monitoredResourceDescription = MetricConfiguration.EMPTY_MONITORED_RESOURCE_DESCRIPTION;
+    this.instrumentationLibraryLabelsEnabled = true;
   }
 
   @Deprecated
@@ -76,8 +78,10 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
     this.monitoredResourceDescription = MetricConfiguration.EMPTY_MONITORED_RESOURCE_DESCRIPTION;
+    this.instrumentationLibraryLabelsEnabled = true;
   }
 
+  @Deprecated
   public AggregateByLabelMetricTimeSeriesBuilder(
       String projectId,
       String prefix,
@@ -87,6 +91,20 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
     this.prefix = prefix;
     this.resourceAttributeFilter = resourceAttributeFilter;
     this.monitoredResourceDescription = monitoredResourceDescription;
+    this.instrumentationLibraryLabelsEnabled = true;
+  }
+
+  public AggregateByLabelMetricTimeSeriesBuilder(
+      String projectId,
+      String prefix,
+      Predicate<AttributeKey<?>> resourceAttributeFilter,
+      MonitoredResourceDescription monitoredResourceDescription,
+      boolean instrumentationLibraryLabelsEnabled) {
+    this.projectId = projectId;
+    this.prefix = prefix;
+    this.resourceAttributeFilter = resourceAttributeFilter;
+    this.monitoredResourceDescription = monitoredResourceDescription;
+    this.instrumentationLibraryLabelsEnabled = instrumentationLibraryLabelsEnabled;
   }
 
   @Override
@@ -161,6 +179,9 @@ public final class AggregateByLabelMetricTimeSeriesBuilder implements MetricTime
 
   private Attributes instrumentationLibraryLabels(
       Attributes attributes, InstrumentationScopeInfo instrumentationScopeInfo) {
+    if (!instrumentationLibraryLabelsEnabled) {
+      return attributes;
+    }
     return attributes.toBuilder()
         .put(
             AttributeKey.stringKey(LABEL_INSTRUMENTATION_SOURCE),

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/InternalMetricExporter.java
@@ -69,6 +69,7 @@ class InternalMetricExporter implements MetricExporter {
   private final Predicate<AttributeKey<?>> resourceAttributesFilter;
   private final boolean useCreateServiceTimeSeries;
   private final MonitoredResourceDescription monitoredResourceDescription;
+  private final boolean instrumentationLibraryLabelsEnabled;
 
   InternalMetricExporter(
       String projectId,
@@ -77,7 +78,8 @@ class InternalMetricExporter implements MetricExporter {
       MetricDescriptorStrategy descriptorStrategy,
       Predicate<AttributeKey<?>> resourceAttributesFilter,
       boolean useCreateServiceTimeSeries,
-      MonitoredResourceDescription monitoredResourceDescription) {
+      MonitoredResourceDescription monitoredResourceDescription,
+      boolean instrumentationLibraryLabelsEnabled) {
     this.projectId = projectId;
     this.prefix = prefix;
     this.metricServiceClient = client;
@@ -85,6 +87,7 @@ class InternalMetricExporter implements MetricExporter {
     this.resourceAttributesFilter = resourceAttributesFilter;
     this.useCreateServiceTimeSeries = useCreateServiceTimeSeries;
     this.monitoredResourceDescription = monitoredResourceDescription;
+    this.instrumentationLibraryLabelsEnabled = instrumentationLibraryLabelsEnabled;
   }
 
   static InternalMetricExporter createWithConfiguration(MetricConfiguration configuration)
@@ -103,7 +106,8 @@ class InternalMetricExporter implements MetricExporter {
         configuration.getDescriptorStrategy(),
         configuration.getResourceAttributesFilter(),
         configuration.getUseServiceTimeSeries(),
-        configuration.getMonitoredResourceDescription());
+        configuration.getMonitoredResourceDescription(),
+        configuration.getInstrumentationLibraryLabelsEnabled());
   }
 
   @VisibleForTesting
@@ -114,7 +118,8 @@ class InternalMetricExporter implements MetricExporter {
       MetricDescriptorStrategy descriptorStrategy,
       Predicate<AttributeKey<?>> resourceAttributesFilter,
       boolean useCreateServiceTimeSeries,
-      MonitoredResourceDescription monitoredResourceDescription) {
+      MonitoredResourceDescription monitoredResourceDescription,
+      boolean instrumentationLibraryLabelsEnabled) {
     return new InternalMetricExporter(
         projectId,
         prefix,
@@ -122,7 +127,8 @@ class InternalMetricExporter implements MetricExporter {
         descriptorStrategy,
         resourceAttributesFilter,
         useCreateServiceTimeSeries,
-        monitoredResourceDescription);
+        monitoredResourceDescription,
+        instrumentationLibraryLabelsEnabled);
   }
 
   private static MetricServiceSettings generateMetricServiceSettings(
@@ -177,7 +183,11 @@ class InternalMetricExporter implements MetricExporter {
     // 3. Fire the set of time series off.
     MetricTimeSeriesBuilder builder =
         new AggregateByLabelMetricTimeSeriesBuilder(
-            projectId, prefix, resourceAttributesFilter, monitoredResourceDescription);
+            projectId,
+            prefix,
+            resourceAttributesFilter,
+            monitoredResourceDescription,
+            instrumentationLibraryLabelsEnabled);
     for (final MetricData metricData : metrics) {
       // Extract all the underlying points.
       switch (metricData.getType()) {

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -77,8 +77,8 @@ public abstract class MetricConfiguration {
    * MetricConfiguration.Builder#setProjectId(String)}, this method returns a {@link Supplier} that
    * supplies the default Project ID.
    *
-   * @see ServiceOptions#getDefaultProjectId()
    * @return a {@link Supplier} for the GCP project ID.
+   * @see ServiceOptions#getDefaultProjectId()
    */
   abstract Supplier<String> getProjectIdSupplier();
 
@@ -104,10 +104,10 @@ public abstract class MetricConfiguration {
   /**
    * Returns the prefix prepended to metric names.
    *
+   * @return the prefix to attach to metrics.
    * @see <a href="https://cloud.google.com/monitoring/custom-metrics#identifier">Custom Metrics
    *     Identifiers</a>
    *     <p>Defaults to workload.googleapis.com.
-   * @return the prefix to attach to metrics.
    */
   public abstract String getPrefix();
 
@@ -182,6 +182,15 @@ public abstract class MetricConfiguration {
   @Nullable
   public abstract MetricServiceSettings getMetricServiceSettings();
 
+  /**
+   * Returns a boolean indicating if the {@link MetricConfiguration} is configured to add
+   * instrumentation library labels to the metric attributes during export.
+   *
+   * @return true if the {@link MetricConfiguration} is configured to add instrumentation library
+   *     lab els to metrics, false otherwise.
+   */
+  public abstract boolean getInstrumentationLibraryLabelsEnabled();
+
   @VisibleForTesting
   abstract boolean getInsecureEndpoint();
 
@@ -206,6 +215,7 @@ public abstract class MetricConfiguration {
         .setDescriptorStrategy(MetricDescriptorStrategy.SEND_ONCE)
         .setInsecureEndpoint(false)
         .setUseServiceTimeSeries(false)
+        .setInstrumentationLibraryLabelsEnabled(true)
         .setResourceAttributesFilter(DEFAULT_RESOURCE_ATTRIBUTES_FILTER)
         .setMonitoredResourceDescription(EMPTY_MONITORED_RESOURCE_DESCRIPTION)
         .setMetricServiceEndpoint(DEFAULT_METRIC_SERVICE_ENDPOINT);
@@ -310,14 +320,36 @@ public abstract class MetricConfiguration {
      *   <li>{@link MetricConfiguration.Builder#setMetricServiceEndpoint(String)}
      * </ul>
      *
-     * The intended effect of setting these values in the configuration should instead be achieved
-     * by configuring the {@link MetricServiceSettings} object.
+     * <p>The intended effect of setting these values in the configuration should instead be
+     * achieved by configuring the {@link MetricServiceSettings} object.
      *
      * @param metricServiceSettings the {@link MetricServiceSettings} containing the configured
      *     options.
      * @return this.
      */
     public abstract Builder setMetricServiceSettings(MetricServiceSettings metricServiceSettings);
+
+    /**
+     * Sets the {@link MetricConfiguration} to configure the exporter to add instrumentation library
+     * labels as metric attributes during export.
+     *
+     * <p>Enabling instrumentation library labels adds the following metric attributes to exported
+     * metric data points:
+     *
+     * <ul>
+     *   <li>instrumentation_source
+     *   <li>instrumentation_version
+     * </ul>
+     *
+     * The value for these metric attributes is retrieved from {@link
+     * io.opentelemetry.sdk.common.InstrumentationScopeInfo}.
+     *
+     * @param instrumentationLibraryLabelsEnabled boolean indicating whether to add instrumentation
+     *     library labels.
+     * @return this.
+     */
+    public abstract Builder setInstrumentationLibraryLabelsEnabled(
+        boolean instrumentationLibraryLabelsEnabled);
 
     @VisibleForTesting
     abstract Builder setInsecureEndpoint(boolean value);

--- a/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
+++ b/exporters/metrics/src/main/java/com/google/cloud/opentelemetry/metric/MetricConfiguration.java
@@ -187,7 +187,7 @@ public abstract class MetricConfiguration {
    * instrumentation library labels to the metric attributes during export.
    *
    * @return true if the {@link MetricConfiguration} is configured to add instrumentation library
-   *     lab els to metrics, false otherwise.
+   *     labels to metrics, false otherwise.
    */
   public abstract boolean getInstrumentationLibraryLabelsEnabled();
 

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -221,7 +221,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.SEND_ONCE,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION,
+            true);
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
     assertTrue(result.isSuccess());
     CompletableResultCode result2 = exporter.export(ImmutableList.of(aMetricData, aHistogram));
@@ -332,7 +333,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION,
+            true);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -455,7 +457,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             DEFAULT_RESOURCE_ATTRIBUTES_FILTER,
             false,
-            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION,
+            true);
     CompletableResultCode result = exporter.export(ImmutableList.of(aHistogram));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
     verify(mockClient, times(1))
@@ -477,7 +480,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             false,
-            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION,
+            true);
 
     MetricData metricData =
         ImmutableMetricData.createDoubleSummary(
@@ -585,7 +589,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             customAttributesFilter,
             false,
-            monitoredResourceDescription);
+            monitoredResourceDescription,
+            true);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricDataWithCustomResource));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -681,7 +686,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             customAttributesFilter,
             false,
-            monitoredResourceDescription);
+            monitoredResourceDescription,
+            true);
 
     CompletableResultCode result = exporter.export(ImmutableList.of(aMetricDataWithCustomResource));
     verify(mockClient, times(1)).createMetricDescriptor(metricDescriptorCaptor.capture());
@@ -696,7 +702,8 @@ public class GoogleCloudMetricExporterTest {
   }
 
   @Test
-  public void testExportWithMonitoredResourceMappingSucceeds_NoResourceLabels() {
+  public void
+      testExportWithMonitoredResourceMappingSucceeds_NoResourceLabels_NoInstrumentationLabels() {
     MonitoredResourceDescription monitoredResourceDescription =
         new MonitoredResourceDescription(
             "custom_mr_instance", Set.of("service_instance_id", "host_id", "location"));
@@ -743,6 +750,7 @@ public class GoogleCloudMetricExporterTest {
             .setValue(TypedValue.newBuilder().setInt64Value(aLongPoint.getValue()))
             .setInterval(expectedTimeInterval)
             .build();
+    // expected timeseries metric does not have the instrumentation library labels
     TimeSeries expectedTimeSeries =
         TimeSeries.newBuilder()
             .setMetric(
@@ -750,8 +758,6 @@ public class GoogleCloudMetricExporterTest {
                     .setType(expectedDescriptor.getType())
                     .putLabels("label1", "value1")
                     .putLabels("label2", "false")
-                    .putLabels(LABEL_INSTRUMENTATION_SOURCE, "instrumentName")
-                    .putLabels(LABEL_INSTRUMENTATION_VERSION, "0")
                     .build())
             .addPoints(expectedPoint)
             .setMetricKind(expectedDescriptor.getMetricKind())
@@ -772,7 +778,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             customAttributesFilter,
             false,
-            monitoredResourceDescription);
+            monitoredResourceDescription,
+            false); // disable instrumentationLibrary labels generation
 
     CompletableResultCode result =
         exporter.export(ImmutableList.of(aMetricDataWithEmptyResourceAttributes));
@@ -849,7 +856,8 @@ public class GoogleCloudMetricExporterTest {
             MetricDescriptorStrategy.ALWAYS_SEND,
             NO_RESOURCE_ATTRIBUTES,
             true,
-            EMPTY_MONITORED_RESOURCE_DESCRIPTION);
+            EMPTY_MONITORED_RESOURCE_DESCRIPTION,
+            true);
 
     CompletableResultCode result =
         exporter.export(ImmutableList.of(googleComputeServiceMetricData));


### PR DESCRIPTION
#### Description
This PR adds a config option - `setInstrumentationLibraryLabelsEnabled(boolean)` that allows the user to configure the exporter to not attach the instrumentation library labels as metric attributes during export.

By default these labels are attached automatically by the exporter during export time.

#### Test
 - Added unit tests to verify the behavior.
 - Tested the config option through the metrics example. 

fixes #357 