### PR TITLE
Migrate e2e tests Container Registry usage to Artifact Registry

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -44,5 +44,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-image.yaml
+++ b/cloudbuild-e2e-image.yaml
@@ -12,40 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
-  # If the image doesn't exist, create a skip file for the next step to know
-  - name: "gcr.io/cloud-builders/gcloud"
-    entrypoint: "bash"
-    args:
-      - -c
-      - |
-        existing_tags=$(
-          gcloud container images list-tags \
-            --filter="tags:${SHORT_SHA}" --format=json \
-            ${_TEST_SERVER_IMAGE_NAME}
-        )
-
-        if [ "$existing_tags" == "[]" ]; then
-          echo "Image doesn't exist, will build it"
-        else
-          echo "Image already exists, will skip building"
-          touch skip
-        fi
-
-  # If skip doesn't exist, build and push
   - name: docker
-    id: build-test-server
     entrypoint: "sh"
     args:
       - -c
       - |
-        if [ -e "skip" ]; then
-          return
-        else
-          docker build --tag=${_TEST_SERVER_IMAGE} --file=e2e.Dockerfile .
-          docker push ${_TEST_SERVER_IMAGE}
+        if docker manifest inspect ${_TEST_SERVER_IMAGE} > /dev/null; then
+          echo "Image already exists, will skip building"
+          exit
         fi
+        docker build --tag=${_TEST_SERVER_IMAGE} --file=e2e.Dockerfile .
+        docker push ${_TEST_SERVER_IMAGE}
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_SERVER_IMAGE: ${_TEST_SERVER_IMAGE_NAME}:${SHORT_SHA}
-  _TEST_SERVER_IMAGE_NAME: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server
+  _TEST_SERVER_IMAGE_NAME: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -21,6 +21,12 @@ steps:
     args:
       - e2e-test-server/wait-for-image.sh
 
+  - name: "docker"
+    id: pull-image
+    args:
+      - pull
+      - $_TEST_SERVER_IMAGE
+
   # Run the test
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-local
@@ -33,5 +39,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-java-e2e-test-server:${SHORT_SHA}

--- a/e2e-test-server/wait-for-image.sh
+++ b/e2e-test-server/wait-for-image.sh
@@ -15,14 +15,11 @@
 # limitations under the License.
 #
 while true; do
-    docker pull $_TEST_SERVER_IMAGE
-    pull_success=$?
-
-    if [ $pull_success -ne 0 ]; then
-        echo "Image couldn't be pulled yet, will continue to retry"
-    else
-        echo "Image pulled successfully, continuing onto test"
+    if docker manifest inspect ${_TEST_SERVER_IMAGE} > /dev/null; then
+        echo "Image is available, continuing onto test"
         break
+    else
+        echo "Image not available yet, will continue to retry"
     fi
     sleep 5
 done


### PR DESCRIPTION
- Push images to GAR
- Upgrading to latest test runner docker image which lives in GAR
- Update `wait-for-image.sh` and build scripts that were coupled to gcr.
