### PR TITLE
Support cloud run jobs in resource detection

### DIFF
--- a/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/AttributeKeys.java
+++ b/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/AttributeKeys.java
@@ -52,6 +52,10 @@ public final class AttributeKeys {
   public static final String SERVERLESS_COMPUTE_CLOUD_REGION = AttributeKeys.CLOUD_REGION;
   public static final String SERVERLESS_COMPUTE_INSTANCE_ID = AttributeKeys.INSTANCE_ID;
 
+  // Cloud Run Job Specific Attributes
+  public static final String GCR_JOB_EXECUTION_KEY = "gcr_job_execution_key";
+  public static final String GCR_JOB_TASK_INDEX = "gcr_job_task_index";
+
   static final String AVAILABILITY_ZONE = "availability_zone";
   static final String CLOUD_REGION = "cloud_region";
   static final String INSTANCE_ID = "instance_id";

--- a/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/GCPPlatformDetector.java
+++ b/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/GCPPlatformDetector.java
@@ -53,6 +53,8 @@ public class GCPPlatformDetector {
       return SupportedPlatform.GOOGLE_CLOUD_RUN;
     } else if (environmentVariables.get("FUNCTION_TARGET") != null) {
       return SupportedPlatform.GOOGLE_CLOUD_FUNCTIONS;
+    } else if (environmentVariables.get("CLOUD_RUN_JOB") != null) {
+      return SupportedPlatform.GOOGLE_CLOUD_RUN_JOB;
     } else if (environmentVariables.get("GAE_SERVICE") != null) {
       return SupportedPlatform.GOOGLE_APP_ENGINE;
     }
@@ -74,6 +76,9 @@ public class GCPPlatformDetector {
         break;
       case GOOGLE_CLOUD_FUNCTIONS:
         detectedPlatform = new GoogleCloudFunction(environmentVariables, metadataConfig);
+        break;
+      case GOOGLE_CLOUD_RUN_JOB:
+        detectedPlatform = new GoogleCloudRunJob(environmentVariables, metadataConfig);
         break;
       case GOOGLE_APP_ENGINE:
         detectedPlatform = new GoogleAppEngine(environmentVariables, metadataConfig);
@@ -98,8 +103,10 @@ public class GCPPlatformDetector {
     GOOGLE_KUBERNETES_ENGINE,
     /** Represents the Google App Engine platform. Could either be flex or standard. */
     GOOGLE_APP_ENGINE,
-    /** Represents the Google Cloud Run platform. */
+    /** Represents the Google Cloud Run platform (Service). */
     GOOGLE_CLOUD_RUN,
+    /** Represents the Google Cloud Run platform (Jobs). */
+    GOOGLE_CLOUD_RUN_JOB,
     /** Represents the Google Cloud Functions platform. */
     GOOGLE_CLOUD_FUNCTIONS,
     /** Represents the case when the application is not running on GCP. */

--- a/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/GoogleCloudRunJob.java
+++ b/detectors/resources-support/src/main/java/com/google/cloud/opentelemetry/detection/GoogleCloudRunJob.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.detection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class GoogleCloudRunJob implements DetectedPlatform {
+  private final GCPMetadataConfig metadataConfig;
+  private final EnvironmentVariables environmentVariables;
+  private final Map<String, String> availableAttributes;
+
+  GoogleCloudRunJob(EnvironmentVariables environmentVariables, GCPMetadataConfig metadataConfig) {
+    this.metadataConfig = metadataConfig;
+    this.environmentVariables = environmentVariables;
+    this.availableAttributes = prepareAttributes();
+  }
+
+  private Map<String, String> prepareAttributes() {
+    Map<String, String> map = new HashMap<>();
+    map.put(AttributeKeys.SERVERLESS_COMPUTE_NAME, this.environmentVariables.get("CLOUD_RUN_JOB"));
+    map.put(
+        AttributeKeys.GCR_JOB_EXECUTION_KEY, this.environmentVariables.get("CLOUD_RUN_EXECUTION"));
+    map.put(
+        AttributeKeys.GCR_JOB_TASK_INDEX, this.environmentVariables.get("CLOUD_RUN_TASK_INDEX"));
+    map.put(AttributeKeys.SERVERLESS_COMPUTE_INSTANCE_ID, this.metadataConfig.getInstanceId());
+    map.put(AttributeKeys.SERVERLESS_COMPUTE_CLOUD_REGION, this.metadataConfig.getRegionFromZone());
+    return map;
+  }
+
+  @Override
+  public GCPPlatformDetector.SupportedPlatform getSupportedPlatform() {
+    return GCPPlatformDetector.SupportedPlatform.GOOGLE_CLOUD_RUN_JOB;
+  }
+
+  @Override
+  public String getProjectId() {
+    return metadataConfig.getProjectId();
+  }
+
+  @Override
+  public Map<String, String> getAttributes() {
+    return this.availableAttributes;
+  }
+}

--- a/detectors/resources-support/src/test/java/com/google/cloud/opentelemetry/detection/GCPPlatformDetectorTest.java
+++ b/detectors/resources-support/src/test/java/com/google/cloud/opentelemetry/detection/GCPPlatformDetectorTest.java
@@ -15,7 +15,19 @@
  */
 package com.google.cloud.opentelemetry.detection;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.google.cloud.opentelemetry.detection.AttributeKeys.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,19 +36,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.google.cloud.opentelemetry.detection.AttributeKeys.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @WireMockTest(httpPort = 8089)
 public class GCPPlatformDetectorTest {

--- a/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
+++ b/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java
@@ -30,6 +30,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.contrib.gcp.resource.GCPResourceProvider;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
@@ -37,6 +38,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public class MetricsExporterExample {
   private static SdkMeterProvider METER_PROVIDER;
@@ -146,9 +148,16 @@ public class MetricsExporterExample {
     } finally {
       System.out.println("Shutting down the metrics-example application");
 
-      METER_PROVIDER.shutdown();
+      CompletableResultCode resultCode = METER_PROVIDER.shutdown();
+      // Wait upto 60 seconds for job to complete
+      resultCode.join(60, TimeUnit.SECONDS);
+      if (resultCode.isSuccess()) {
+        System.out.println("Shutdown completed successfully!");
+      } else {
+        System.out.println("Unable to shutdown gracefully!");
+      }
 
-      System.out.println("Shutdown complete");
+      System.out.println("Exiting job");
     }
   }
 }


### PR DESCRIPTION
### Description
Adds support for detecting Cloud Run Jobs environment.

### Testing
 - Added unit tests pass + Build work.
 - Tested with manually built resource-detection library.
      - Debug exporter export output. 
`
INFO: metric: ImmutableMetricData{resource=Resource{schemaUrl=null, attributes={cloud.account.id="otel-test", cloud.platform="gcp_cloud_run", cloud.provider="gcp", cloud.region="us-central1", faas.instance="003fb3e0c8b947e4481e1e7e76dc3c594af483befe470a0bbb6fff27f96fa9caa77e6e202dcea43a646942", faas.name="job-metrics-export", gcp.cloud_run.job.execution="job-metrics-export-sprng", gcp.cloud_run.job.task_index=0}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=instrumentation-library-name, version=semver:1.0.0, schemaUrl=null, attributes={}}, name=example_counter, description=Processed jobs, unit=1, type=LONG_SUM, data=ImmutableSumData{points=[ImmutableLongPointData{startEpochNanos=1726685490477889000, epochNanos=1726685512168409000, attributes={}, value=968, exemplars=[]}], monotonic=true, aggregationTemporality=CUMULATIVE}}
` 

Re #369 