### PR TITLE
Hardcode versions on all samples

### DIFF
--- a/examples/autoconf/build.gradle
+++ b/examples/autoconf/build.gradle
@@ -19,8 +19,10 @@ plugins {
 	id 'com.google.cloud.tools.jib'
 }
 
-
 description = 'Examples for using java autoconfiguration and Google Cloud Operations'
+
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
 
 dependencies {
 	implementation(libraries.opentelemetry_api)

--- a/examples/autoconf/build.gradle
+++ b/examples/autoconf/build.gradle
@@ -22,7 +22,7 @@ plugins {
 description = 'Examples for using java autoconfiguration and Google Cloud Operations'
 
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 dependencies {
 	implementation(libraries.opentelemetry_api)

--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -22,6 +22,9 @@ plugins {
 
 description = 'Examples for using java auto instrumentation and Google Cloud Operations'
 
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
+
 configurations {
 	agent
 }

--- a/examples/autoinstrument/build.gradle
+++ b/examples/autoinstrument/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = 'Examples for using java auto instrumentation and Google Cloud Operations'
 
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 configurations {
 	agent

--- a/examples/metrics/build.gradle
+++ b/examples/metrics/build.gradle
@@ -19,6 +19,9 @@ plugins {
 	id 'com.google.cloud.tools.jib'
 }
 
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
+
 // Set Docker image path here, e.g. using Google Container Registry or Docker Hub
 // https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#configuration
 jib {

--- a/examples/metrics/build.gradle
+++ b/examples/metrics/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 // Set Docker image path here, e.g. using Google Container Registry or Docker Hub
 // https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#configuration

--- a/examples/otlp-spring/build.gradle
+++ b/examples/otlp-spring/build.gradle
@@ -23,6 +23,9 @@ description = 'Example showcasing OTLP trace ingest on GCP and Google Auth in a 
 
 group 'com.google.cloud.opentelemetry.examples'
 
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
+
 repositories {
 	mavenCentral()
 }

--- a/examples/otlp-spring/build.gradle
+++ b/examples/otlp-spring/build.gradle
@@ -21,8 +21,6 @@ plugins {
 
 description = 'Example showcasing OTLP trace ingest on GCP and Google Auth in a Spring Boot App'
 
-group 'com.google.cloud.opentelemetry.examples'
-
 // examples are not published, so version can be hardcoded
 version = '1.0.0'
 

--- a/examples/otlp-spring/build.gradle
+++ b/examples/otlp-spring/build.gradle
@@ -22,7 +22,7 @@ plugins {
 description = 'Example showcasing OTLP trace ingest on GCP and Google Auth in a Spring Boot App'
 
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 repositories {
 	mavenCentral()

--- a/examples/otlpmetrics-function/build.gradle
+++ b/examples/otlpmetrics-function/build.gradle
@@ -21,7 +21,7 @@ plugins {
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 repositories {
 	mavenCentral()

--- a/examples/otlpmetrics-function/build.gradle
+++ b/examples/otlpmetrics-function/build.gradle
@@ -20,7 +20,8 @@ plugins {
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-group 'org.example'
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
 
 repositories {
 	mavenCentral()

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -18,7 +18,7 @@ plugins {
 	id 'application'
 }
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 mainClassName = 'com.google.cloud.opentelemetry.example.otlptrace.OTLPTraceExample'
 

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -17,6 +17,8 @@ plugins {
 	id 'java'
 	id 'application'
 }
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
 
 mainClassName = 'com.google.cloud.opentelemetry.example.otlptrace.OTLPTraceExample'
 

--- a/examples/resource/build.gradle
+++ b/examples/resource/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'com.google.cloud.tools.jib'
 }
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 description = 'Examples for showing resource detection in various GCP environments.'
 

--- a/examples/resource/build.gradle
+++ b/examples/resource/build.gradle
@@ -18,6 +18,8 @@ plugins {
 	id 'application'
 	id 'com.google.cloud.tools.jib'
 }
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
 
 description = 'Examples for showing resource detection in various GCP environments.'
 

--- a/examples/spring-sleuth/README.md
+++ b/examples/spring-sleuth/README.md
@@ -35,7 +35,7 @@ cd examples/spring-sleuth/ && gradle bootJar
 The JAR built from the previous command typically ends up in `build/libs` -
 
 ```shell
-java -jar build/libs/examples-spring-sleuth-1.0.0.jar
+java -jar build/libs/examples-spring-sleuth-0.1.0.jar
 ```
 
 The application is now running. To generate traces, head to `http://localhost:8080` in your browser.

--- a/examples/spring-sleuth/README.md
+++ b/examples/spring-sleuth/README.md
@@ -35,7 +35,7 @@ cd examples/spring-sleuth/ && gradle bootJar
 The JAR built from the previous command typically ends up in `build/libs` -
 
 ```shell
-java -jar build/libs/examples-spring-sleuth-0.1.0-SNAPSHOT.jar
+java -jar build/libs/examples-spring-sleuth-1.0.0.jar
 ```
 
 The application is now running. To generate traces, head to `http://localhost:8080` in your browser.

--- a/examples/spring-sleuth/build.gradle
+++ b/examples/spring-sleuth/build.gradle
@@ -18,6 +18,8 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }
+// examples are not published, so version can be hardcoded
+version = "1.0.0"
 
 jar {
 	manifest {

--- a/examples/spring-sleuth/build.gradle
+++ b/examples/spring-sleuth/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'java'
 }
 // examples are not published, so version can be hardcoded
-version = "1.0.0"
+version = '0.1.0'
 
 jar {
 	manifest {

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -21,7 +21,7 @@ plugins {
 	id 'com.google.cloud.tools.jib'
 }
 // examples are not published, so version can be hardcoded
-version = '1.0.0'
+version = '0.1.0'
 
 repositories {
 	mavenCentral()
@@ -60,7 +60,7 @@ tasks.register('runApp', JavaExec) {
 	description = "Builds and runs the spring application's execuable JAR"
 
 	dependsOn tasks.bootJar
-	classpath = files('build/libs/examples-spring-1.0.0.jar')
+	classpath = files('build/libs/examples-spring-0.1.0.jar')
 	jvmArgs = autoconf_config
 }
 

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -20,6 +20,8 @@ plugins {
 	id 'application'
 	id 'com.google.cloud.tools.jib'
 }
+// examples are not published, so version can be hardcoded
+version = '1.0.0'
 
 repositories {
 	mavenCentral()
@@ -37,7 +39,7 @@ jar {
 
 // OpenTelemetry Autoconfigure module can be configured using system properties
 def autoconf_config = [
-	'-Dotel.resource.attributes=gcp.project_id=otel-test-sharmapranav',
+	'-Dotel.resource.attributes=gcp.project_id=<your-awesome-gcp-project>',
 	'-Dotel.traces.exporter=google_cloud_trace',
 	'-Dotel.metrics.exporter=google_cloud_monitoring,logging',
 	'-Dotel.logs.exporter=none',
@@ -58,7 +60,7 @@ tasks.register('runApp', JavaExec) {
 	description = "Builds and runs the spring application's execuable JAR"
 
 	dependsOn tasks.bootJar
-	classpath = files('build/libs/examples-spring-0.1.0-SNAPSHOT.jar')
+	classpath = files('build/libs/examples-spring-1.0.0.jar')
 	jvmArgs = autoconf_config
 }
 

--- a/examples/spring/build.gradle
+++ b/examples/spring/build.gradle
@@ -39,7 +39,7 @@ jar {
 
 // OpenTelemetry Autoconfigure module can be configured using system properties
 def autoconf_config = [
-	'-Dotel.resource.attributes=gcp.project_id=<your-awesome-gcp-project>',
+	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT>',
 	'-Dotel.traces.exporter=google_cloud_trace',
 	'-Dotel.metrics.exporter=google_cloud_monitoring,logging',
 	'-Dotel.logs.exporter=none',


### PR DESCRIPTION
This PR hard-codes version number on all samples since they are not meant to be published on maven. 

Hardcoding samples simplifies writing docs and instructions as it gives us deterministic file names from the build output.

Also removes `group` declaration on a few example modules to keep things consistent.