### PR TITLE
Make project compatible with Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ subprojects {
 		openTelemetryContribVersion = '1.39.0'
 		junitVersion = '4.13'
 		junit5Version = '5.10.0'
-		mockitoVersion = '3.5.10'
+		mockitoVersion = '5.2.0'
 		pubSubVersion = '1.133.0'
 		testContainersVersion = '1.15.1'
 		wiremockVersion = '2.35.0'

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/GoogleCloudMetricExporterTest.java
@@ -171,7 +171,7 @@ public class GoogleCloudMetricExporterTest {
       // verify that the MetricServiceClient used in the exporter was created using the
       // MetricServiceSettings provided in configuration
       mockedServiceClientClass.verify(
-          times(1), () -> MetricServiceClient.create(eq(configuration.getMetricServiceSettings())));
+          () -> MetricServiceClient.create(eq(configuration.getMetricServiceSettings())), times(1));
 
       // verify that export operation on the resulting exporter can still be called
       CompletableResultCode result = exporter.export(ImmutableList.of(aMetricData, aHistogram));
@@ -816,9 +816,9 @@ public class GoogleCloudMetricExporterTest {
       simulateExport(metricExporter);
 
       mockedMetricServiceClient.verify(
-          Mockito.times(1),
-          () -> MetricServiceClient.create((MetricServiceSettings) Mockito.any()));
-      mockedServiceOptions.verify(Mockito.times(1), ServiceOptions::getDefaultProjectId);
+          () -> MetricServiceClient.create((MetricServiceSettings) Mockito.any()),
+          Mockito.times(1));
+      mockedServiceOptions.verify(ServiceOptions::getDefaultProjectId, Mockito.times(1));
       Mockito.verify(this.mockMetricServiceClient)
           .createTimeSeries((ProjectName) Mockito.any(), Mockito.anyList());
     } finally {

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/MetricConfigurationTest.java
@@ -107,7 +107,7 @@ public class MetricConfigurationTest {
 
       MetricConfiguration configuration = MetricConfiguration.builder().build();
       assertEquals(PROJECT_ID, configuration.getProjectId());
-      serviceOptionsMockedStatic.verify(Mockito.times(1), ServiceOptions::getDefaultProjectId);
+      serviceOptionsMockedStatic.verify(ServiceOptions::getDefaultProjectId, Mockito.times(1));
     }
   }
 
@@ -127,7 +127,7 @@ public class MetricConfigurationTest {
       metricConfiguration2.getProjectId();
 
       // ServiceOptions#getDefaultProjectId should only be called once per TraceConfiguration object
-      serviceOptionsMockedStatic.verify(Mockito.times(2), ServiceOptions::getDefaultProjectId);
+      serviceOptionsMockedStatic.verify(ServiceOptions::getDefaultProjectId, Mockito.times(2));
     }
   }
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceConfigurationTest.java
@@ -98,7 +98,7 @@ public class TraceConfigurationTest {
       TraceConfiguration traceConfiguration = TraceConfiguration.builder().build();
       assertEquals(PROJECT_ID, traceConfiguration.getProjectId());
 
-      mockedServiceOptions.verify(Mockito.times(1), ServiceOptions::getDefaultProjectId);
+      mockedServiceOptions.verify(ServiceOptions::getDefaultProjectId, Mockito.times(1));
     }
   }
 
@@ -164,7 +164,7 @@ public class TraceConfigurationTest {
       traceConfiguration2.getProjectId();
 
       // ServiceOptions#getDefaultProjectId should only be called once per TraceConfiguration object
-      serviceOptionsMockedStatic.verify(Mockito.times(2), ServiceOptions::getDefaultProjectId);
+      serviceOptionsMockedStatic.verify(ServiceOptions::getDefaultProjectId, Mockito.times(2));
     }
   }
 }

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/TraceExporterTest.java
@@ -101,8 +101,8 @@ public class TraceExporterTest {
       simulateExport(exporter);
 
       mockedTraceServiceClient.verify(
-          Mockito.times(1), () -> TraceServiceClient.create((TraceServiceSettings) Mockito.any()));
-      mockedServiceOptions.verify(Mockito.times(1), ServiceOptions::getDefaultProjectId);
+          () -> TraceServiceClient.create((TraceServiceSettings) Mockito.any()), Mockito.times(1));
+      mockedServiceOptions.verify(ServiceOptions::getDefaultProjectId, Mockito.times(1));
       Mockito.verify(this.mockedTraceServiceClient)
           .batchWriteSpans((ProjectName) Mockito.any(), Mockito.anyList());
     }


### PR DESCRIPTION
Mockito 3.5.x is incompatible when building with Java 17, therefore an update to a more recent version of Mockito is required. There have been breaking changes in Mockito's releases which are difficult to point out. Some tests required code changes to make them compatible with these changes.
Only breaking change that affected this codebase was the handling of static mocks.

This change only makes the project compatible with Java 17. 
 - Minimum Java version required to build is Java 11.
 - Artifacts produced are still Java 8 compatible, unless otherwise stated.
 
 Mockito 3.x is also ~5 yrs old at this point.