### PR TITLE
Use exponential histograms in the quickstart sample

### DIFF
--- a/examples/instrumentation-quickstart/docker-compose.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
       - OTEL_SERVICE_NAME=otel-quickstart-spring-boot
       - OTEL_METRIC_EXPORT_INTERVAL=5000
+      - OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
     volumes:
       - logs:/var/log:rw
     ports:

--- a/examples/instrumentation-quickstart/docker-compose.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - "otelcol"
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.107.0
+    image: otel/opentelemetry-collector-contrib:0.115.1
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - logs:/var/log:ro

--- a/examples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/examples/instrumentation-quickstart/otel-collector-config.yaml
@@ -109,6 +109,14 @@ processors:
     detectors: ["env", "gcp"]
 
 service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
   pipelines:
     traces:
       receivers: ["otlp"]


### PR DESCRIPTION
Also, update the collector image.  This is the same as https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/364.

Tested by running the quickstart myself and verifying the metrics, traces and logs.