### PR TITLE
Add otlp metric example with gcp auth

### DIFF
--- a/examples/otlpmetric/README.md
+++ b/examples/otlpmetric/README.md
@@ -1,0 +1,33 @@
+# OTLP Metric with Google Auth Example
+
+Run this sample to connect to an endpoint that is protected by GCP authentication.
+
+First, get GCP credentials on your machine:
+
+```shell
+gcloud auth application-default login
+```
+Executing this command will save your application credentials to default path which will depend on the type of machine -
+ - Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+ - Windows: `%APPDATA%\gcloud\application_default_credentials.json`
+
+Next, set your endpoint with the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable:
+
+```shell
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-endpoint:port"
+```
+
+Next, update [`build.gradle`](build.grade) to set the following:
+
+```
+	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT_ID>,
+	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
+	# Optional - if you want to export using gRPC protocol
+	'-Dotel.exporter.otlp.protocol=grpc',
+```
+
+Finally, to run the sample from the project root:
+
+```
+cd examples/otlpmetric && gradle run
+```

--- a/examples/otlpmetric/build.gradle
+++ b/examples/otlpmetric/build.gradle
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+	id 'java'
+	id 'application'
+}
+// examples are not published, so version can be hardcoded
+version = '0.1.0'
+
+mainClassName = 'com.google.cloud.opentelemetry.example.otlpmetric.OTLPMetricExample'
+
+description = 'Example for OTLP Metric exporter'
+
+dependencies {
+	implementation(libraries.opentelemetry_api)
+	implementation(libraries.opentelemetry_sdk)
+	implementation(libraries.opentelemetry_otlp_exporter)
+	implementation(libraries.opentelemetry_sdk_autoconf)
+	implementation(libraries.google_auth)
+}
+
+// Provide headers from env variable
+// export OTEL_EXPORTER_OTLP_ENDPOINT="http://path/to/yourendpoint:port"
+def autoconf_config = [
+	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT>',
+	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
+	'-Dotel.metrics.exporter=otlp',
+	'-Dotel.exporter.otlp.protocol=http/protobuf',
+	'-Dotel.java.global-autoconfigure.enabled=true',
+]
+
+application {
+	applicationDefaultJvmArgs = autoconf_config
+}

--- a/examples/otlpmetric/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPMetricExample.java
+++ b/examples/otlpmetric/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPMetricExample.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.opentelemetry.example.otlpmetric;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import io.opentelemetry.api.metric.Metric;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporterBuilder;
+import io.opentelemetry.exporter.otlp.metric.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.metric.OtlpGrpcMetricExporterBuilder;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metric.export.MetricExporter;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class OTLPMetricExample {
+  private static final String INSTRUMENTATION_SCOPE_NAME = OTLPMetricExample.class.getName();
+  private static final Random random = new Random();
+
+  private static OpenTelemetrySdk openTelemetrySdk;
+
+  private static OpenTelemetrySdk setupMetricExporter() throws IOException {
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+
+    // Update the SDK configured using environment variables and system properties
+    AutoConfiguredOpenTelemetrySdk autoConfOTelSdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .addMetricExporterCustomizer(
+                (exporter, configProperties) -> addAuthorizationHeaders(exporter, credentials))
+            .build();
+    return autoConfOTelSdk.getOpenTelemetrySdk();
+  }
+
+  // Modifies the metric exporter initially auto-configured using environment variables
+  // Note: This adds static authorization headers which are set only at initialization time.
+  // This will stop working after the token expires, since the token is not refreshed.
+  private static MetricExporter addAuthorizationHeaders(
+      MetricExporter exporter, GoogleCredentials credentials) {
+    if (exporter instanceof OtlpHttpMetricExporter) {
+      try {
+        credentials.refreshIfExpired();
+        OtlpHttpMetricExporterBuilder builder =
+            ((OtlpHttpMetricExporter) exporter)
+                .toBuilder()
+                    .addHeader(
+                        "Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
+
+        return builder.build();
+      } catch (IOException e) {
+        System.out.println("error:" + e.getMessage());
+      }
+    } else if (exporter instanceof OtlpGrpcMetricExporter) {
+      try {
+        credentials.refreshIfExpired();
+        OtlpGrpcMetricExporterBuilder builder =
+            ((OtlpGrpcMetricExporter) exporter)
+                .toBuilder()
+                    .addHeader(
+                        "Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
+        return builder.build();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return exporter;
+  }
+
+  private static void myUseCase() {
+    LongCounter counter =
+        METER
+            .counterBuilder("example_counter")
+            .setDescription("Processed jobs")
+            .setUnit("1")
+            .build();
+    doWork(counter);
+  }
+
+  private static void doWork(LongCounter counter) {
+    try {
+      for (int i = 0; i < 10; i++) {
+        counter.add(RANDOM.nextInt(100));
+        Thread.sleep(RANDOM.nextInt(1000));
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    // Configure the OpenTelemetry pipeline with CloudMetric exporter
+    openTelemetrySdk = setupMetricExporter();
+
+    // Application-specific logic
+    myUseCase("One");
+    myUseCase("Two");
+
+    // Flush all buffered metrics
+    CompletableResultCode completableResultCode =
+        openTelemetrySdk.getSdkMeterProvider().shutdown();
+    // wait till export finishes
+    completableResultCode.join(10000, TimeUnit.MILLISECONDS);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ include ":exporter-trace"
 include ":examples-trace"
 include ":examples-otlp-spring"
 include ":examples-otlptrace"
+include ":examples-otlpmetric"
 include ":examples-otlpmetrics-function"
 include ":exporter-metrics"
 include ":examples-metrics"
@@ -107,3 +108,6 @@ project(':examples-spring').projectDir =
 
 project(':examples-otlpmetrics-function').projectDir =
 		"$rootDir/examples/otlpmetrics-function" as File
+
+project(':examples-otlpmetric').projectDir =
+		"$rootDir/examples/otlpmetric" as File


### PR DESCRIPTION
This is a copy of https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/examples/otlptrace, but changed to use metrics (based on https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/blob/main/examples/metrics/src/main/java/com/google/cloud/opentelemetry/example/metrics/MetricsExporterExample.java).

TODO: test