### PR TITLE
Update OTLP Trace Example to use Auth Extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ subprojects {
 		openTelemetryInstrumentationBomVersion = '2.8.0'
 		openTelemetryInstrumentationVersion = '2.8.0'
 		openTelemetrySemconvVersion = '1.27.0'
-		openTelemetryContribVersion = '1.39.0'
+		openTelemetryContribVersion = '1.43.0'
 		junitVersion = '4.13'
 		junit5Version = '5.10.0'
 		mockitoVersion = '5.2.0'
@@ -212,6 +212,7 @@ subprojects {
 			opentelemetry_otlp_exporter      : "io.opentelemetry:opentelemetry-exporter-otlp:${openTelemetryVersion}",
 			opentelemetry_logging_exporter   : "io.opentelemetry:opentelemetry-exporter-logging:${openTelemetryVersion}",
 			opentelemetry_gcp_resources      : "io.opentelemetry.contrib:opentelemetry-gcp-resources:${openTelemetryContribVersion}-alpha",
+			opentelemetry_gcp_auth_extension : "io.opentelemetry.contrib:opentelemetry-gcp-auth-extension:${openTelemetryContribVersion}-alpha",
 			spring_boot_starter              : "org.springframework.boot:spring-boot-starter:${springVersion}",
 			spring_boot_starter_web          : "org.springframework.boot:spring-boot-starter-web:${springWebVersion}",
 			spring_boot_starter_actuator     : "org.springframework.boot:spring-boot-starter-actuator:${springVersion}",

--- a/examples/otlptrace/README.md
+++ b/examples/otlptrace/README.md
@@ -17,15 +17,6 @@ Next, set your endpoint with the `OTEL_EXPORTER_OTLP_ENDPOINT` environment varia
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-endpoint:port"
 ```
 
-Next, update [`build.gradle`](build.grade) to set the following:
-
-```
-	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT_ID>,
-	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
-	# Optional - if you want to export using gRPC protocol
-	'-Dotel.exporter.otlp.protocol=grpc',
-```
-
 Finally, to run the sample from the project root:
 
 ```

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -27,17 +27,16 @@ dependencies {
 	implementation(libraries.opentelemetry_sdk)
 	implementation(libraries.opentelemetry_otlp_exporter)
 	implementation(libraries.opentelemetry_sdk_autoconf)
-	implementation(libraries.google_auth)
-	implementation(libraries.opentelemetry_gcp_auth_extension)
+	// the shaded variant name is empty
+	implementation("${libraries.opentelemetry_gcp_auth_extension}:")
 	implementation(libraries.opentelemetry_gcp_resources)
-	implementation(libraries.opentelemetry_logging_exporter)
 }
 
 // Provide headers from env variable
 def autoconf_config = [
-	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT>',
-	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
-	'-Dotel.traces.exporter=otlp,console',
+	'-Dgoogle.cloud.project=your-gcp-project-id',
+	'-Dotel.exporter.otlp.endpoint=https://your-api-endpoint:port',
+	'-Dotel.traces.exporter=otlp',
 	'-Dotel.logs.exporter=none',
 	'-Dotel.metrics.exporter=none',
 	'-Dotel.service.name=otlptrace-example',

--- a/examples/otlptrace/build.gradle
+++ b/examples/otlptrace/build.gradle
@@ -20,8 +20,6 @@ plugins {
 // examples are not published, so version can be hardcoded
 version = '0.1.0'
 
-mainClassName = 'com.google.cloud.opentelemetry.example.otlptrace.OTLPTraceExample'
-
 description = 'Example for OTLP exporter'
 
 dependencies {
@@ -30,18 +28,24 @@ dependencies {
 	implementation(libraries.opentelemetry_otlp_exporter)
 	implementation(libraries.opentelemetry_sdk_autoconf)
 	implementation(libraries.google_auth)
+	implementation(libraries.opentelemetry_gcp_auth_extension)
+	implementation(libraries.opentelemetry_gcp_resources)
+	implementation(libraries.opentelemetry_logging_exporter)
 }
 
 // Provide headers from env variable
-// export OTEL_EXPORTER_OTLP_ENDPOINT="http://path/to/yourendpoint:port"
 def autoconf_config = [
 	'-Dotel.resource.attributes=gcp.project_id=<YOUR_PROJECT>',
 	'-Dotel.exporter.otlp.headers=X-Goog-User-Project=<YOUR_QUOTA_PROJECT>',
-	'-Dotel.traces.exporter=otlp',
+	'-Dotel.traces.exporter=otlp,console',
+	'-Dotel.logs.exporter=none',
+	'-Dotel.metrics.exporter=none',
+	'-Dotel.service.name=otlptrace-example',
 	'-Dotel.exporter.otlp.protocol=http/protobuf',
 	'-Dotel.java.global-autoconfigure.enabled=true',
 ]
 
 application {
+	mainClassName = 'com.google.cloud.opentelemetry.example.otlptrace.OTLPTraceExample'
 	applicationDefaultJvmArgs = autoconf_config
 }

--- a/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
+++ b/examples/otlptrace/src/main/java/com/google/cloud/opentelemetry/example/otlptrace/OTLPTraceExample.java
@@ -93,7 +93,6 @@ public class OTLPTraceExample {
         String work = String.format("%s - Work #%d", description, (i + 1));
         doWork(work);
       }
-
       span.addEvent("Event B");
     } finally {
       span.end();
@@ -106,7 +105,9 @@ public class OTLPTraceExample {
         openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE_NAME).spanBuilder(description).startSpan();
     try (Scope scope = span.makeCurrent()) {
       // Simulate work: this could be simulating a network request or an expensive disk operation
-      Thread.sleep(100 + random.nextInt(5) * 100);
+      int randomSleep = random.nextInt(5) * 100;
+      span.setAttribute("RandomSleep", randomSleep);
+      Thread.sleep(100 + randomSleep);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     } finally {


### PR DESCRIPTION
Updates the OTLP Trace example to use the [GCP Auth Extension](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-auth-extension) to export traces to GCP.