### PR TITLE
Remove the use of GlobalOpenTelemetry

### DIFF
--- a/examples/autoconf/build.gradle
+++ b/examples/autoconf/build.gradle
@@ -27,8 +27,8 @@ version = '0.1.0'
 dependencies {
 	implementation(libraries.opentelemetry_api)
 	implementation(libraries.opentelemetry_sdk_metrics)
-	runtimeOnly(libraries.opentelemetry_sdk_autoconf)
-	runtimeOnly(libraries.opentelemetry_sdk)
+	implementation(libraries.opentelemetry_sdk_autoconf)
+	implementation(libraries.opentelemetry_sdk)
 	runtimeOnly project(':exporter-auto')
 	// Provides resources to the autoconfiguration module
 	runtimeOnly(libraries.opentelemetry_gcp_resources)
@@ -44,10 +44,9 @@ def autoconf_config = [
 	'-Dotel.service.name=example-autoconf-service',
 ]
 
-mainClassName = 'com.google.cloud.opentelemetry.example.autoconf.AutoconfExample'
-
 application {
 	applicationDefaultJvmArgs = autoconf_config
+	mainClassName = 'com.google.cloud.opentelemetry.example.autoconf.AutoconfExample'
 }
 
 


### PR DESCRIPTION
#### Description
Replaces the use of `GlobalOpenTelemetry` with `AutoConfiguredOpenTelemetrySdk`. 

From the [documentation](https://github.com/open-telemetry/opentelemetry-java/blob/cb64451c72a96a65d9d32a997852b87c150fcf2f/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java#L26-L45) of `GlobalOpenTelemetry`, it is recommended not to use it, unless absolutely necessary.

This sample can function without `GlobalOpenTelemetry`.

#### Testing
 - Ran the sample manually to generate telemetry. 
 - Verified generated metrics & traces