### PR TITLE
Add GCB config for uninstrumented quickstart

### DIFF
--- a/examples/instrumentation-quickstart/cloudbuild-uninstrumented-app.yaml
+++ b/examples/instrumentation-quickstart/cloudbuild-uninstrumented-app.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration to build the un-instrumented version of this quickstart on
+# Google Cloud Build. Also pushes the built image to Google Artifact Registry.
+# REGISTRY_LOCATION, PROJECT_ID, ARTIFACT_REGISTRY environment variables must be
+# substituted in this file.
+#
+# Using gCloud CLI:
+# gcloud builds submit --config <(envsubst < cloudbuild-uninstrumented-app.yaml) .
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  env:
+  - 'DOCKER_BUILDKIT=1'
+  args: [ 'build', '-t', '${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REGISTRY}/java-quickstart:latest', '-f', 'uninstrumented.Dockerfile', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'push', '${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REGISTRY}/java-quickstart:latest' ]
+images: ['${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REGISTRY}/java-quickstart:latest']


### PR DESCRIPTION
Adds a Configuration to allow building uninstrumented version of quickstart sample on Google Cloud Build. The config file is configured to read environment variables and push the built image to Google Artifact Registry.

#### Testing
 - Ran `gcloud builds submit --config <(envsubst < cloudbuild-uninstrumented-app.yaml) .` to successfully build and push the image to Google Artifact Registry.