### PR TITLE
chore: Update loadgen service's Docker image to Go 1.24.

### DIFF
--- a/examples/instrumentation-quickstart/docker-compose.yaml
+++ b/examples/instrumentation-quickstart/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       # Collector prometheus port. The metrics are checked in tests
       - 8888
   loadgen:
-    image: golang:1.21
+    image: golang:1.24
     command:
       [
         "go",

--- a/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
+++ b/exporters/metrics/src/test/java/com/google/cloud/opentelemetry/metric/EndToEndTest.java
@@ -43,7 +43,7 @@ public class EndToEndTest {
               .withDockerfileFromBuilder(
                   builder ->
                       builder
-                          .from("golang:1.17")
+                          .from("golang:1.24")
                           .run(
                               "go install github.com/googleinterns/cloud-operations-api-mock/cmd@v2-alpha")
                           .cmd("cmd --address=:8080")

--- a/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
+++ b/exporters/trace/src/test/java/com/google/cloud/opentelemetry/trace/EndToEndTest.java
@@ -67,7 +67,7 @@ public class EndToEndTest {
               .withDockerfileFromBuilder(
                   builder ->
                       builder
-                          .from("golang:1.17")
+                          .from("golang:1.24")
                           .run(
                               "go install github.com/googleinterns/cloud-operations-api-mock/cmd@v2-alpha")
                           .cmd("cmd --address=:8080")


### PR DESCRIPTION
## Summary
The `loadgen` service in [examples/instrumentation-quickstart/docker-compose.yaml](file:///usr/local/google/home/adarshkr/Documents/github/opentelemetry-operations-java/examples/instrumentation-quickstart/docker-compose.yaml) fails to start because it uses the `golang:1.21` image, but the `command` attempts to run `github.com/rakyll/hey@latest`. The latest version of `hey` (v0.1.5) requires Go 1.24 or higher.

## Steps to Reproduce
1. Clone the repository: `git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-java.git`
2. Navigate to the example: `cd opentelemetry-operations-java/examples/instrumentation-quickstart`
3. Run the example: `docker compose up`

## Expected Behavior
The `loadgen` container should start successfully and generate load against the application.

## Actual Behavior
The `loadgen` container exits immediately with the following error:

```
loadgen-1  | go: downloading github.com/rakyll/hey v0.1.5
loadgen-1  | go: github.com/rakyll/hey@latest: github.com/rakyll/hey@v0.1.5 requires go >= 1.24.0 (running go 1.21.13; GOTOOLCHAIN=local)
```

This causes the entire compose stack to shut down if `--abort-on-container-exit` is used (as recommended in the README).

## Environment
- **Repository:** `GoogleCloudPlatform/opentelemetry-operations-java`
- **Path:** `examples/instrumentation-quickstart`
- **File:** [docker-compose.yaml](file:///usr/local/google/home/adarshkr/Documents/github/opentelemetry-operations-java/examples/instrumentation-quickstart/docker-compose.yaml)
- **Docker Image:** `golang:1.21` (Current)

## Proposed Fix
Update the `loadgen` service in [docker-compose.yaml](file:///usr/local/google/home/adarshkr/Documents/github/opentelemetry-operations-java/examples/instrumentation-quickstart/docker-compose.yaml) to use a newer Go image, such as `golang:1.24` or `golang:latest`.