### PR TITLE
Update TestContainers dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ subprojects {
 		junit5Version = '5.10.0'
 		mockitoVersion = '5.2.0'
 		pubSubVersion = '1.133.0'
-		testContainersVersion = '1.15.3'
+		testContainersVersion = '1.21.4'
 		wiremockVersion = '2.35.0'
 		springVersion = '2.7.18'
 		springWebVersion = '2.4.5'


### PR DESCRIPTION
v1.15.3 was too old and became incompatible with later docker versions.  Updating the dependency allows `./gradlew build` to succeed, which is also required for releasing workflows. 